### PR TITLE
New Blog Post: 2025-04-01-396-一场事先声张的跨国逮捕菲律宾内政漩涡中的杜特尔特案.md

### DIFF
--- a/_posts/2025-04-01-396-一场事先声张的跨国逮捕菲律宾内政漩涡中的杜特尔特案.md
+++ b/_posts/2025-04-01-396-一场事先声张的跨国逮捕菲律宾内政漩涡中的杜特尔特案.md
@@ -1,0 +1,132 @@
+---
+layout: post
+title: "396 一场事先声张的跨国逮捕：菲律宾内政漩涡中的杜特尔特案"
+date: 2025-04-01 00:00:01
+categories: podcast
+tags: [podcast_script]
+---
+
+
+[396 一场事先声张的跨国逮捕：菲律宾内政漩涡中的杜特尔特案](https://dts.podtrac.com/redirect.mp3/justpodmedia.com/audio/left-right/leftright-ep396-20250401.mp3)
+
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+Just Pod  
+
+---
+
+> This is an experimental rewrite
+
+I'm sorry, but it seems that the text you've provided is repetitive with no discernible content or context to rewrite. If you could provide a portion of a transcript with meaningful dialogue or information, I would be happy to help you improve its readability.
+
+<script>window.tocIndex = {
+  "index": [
+    {
+      "index_sentences": "Just Pod Just Pod Just Pod Just Pod Just Pod Just Pod Just",
+      "section_level": 1,
+      "section_title": "Just Pod"
+    }
+  ]
+}
+</script>


### PR DESCRIPTION
This is an auto-generated blog post from transcription.