### PR TITLE
Add interactive Apache Spark data-flow explainer

### DIFF
--- a/explainers/index.html
+++ b/explainers/index.html
@@ -189,6 +189,10 @@
                     <span class="entry-title">Claude Code</span>
                     <span class="entry-slug">claude-code-data-flow/</span>
                 </a>
+                <a class="entry" href="spark-data-flow/">
+                    <span class="entry-title">Apache Spark</span>
+                    <span class="entry-slug">spark-data-flow/</span>
+                </a>
             </div>
         </div>
     </body>

--- a/explainers/spark-data-flow/assets/site.js
+++ b/explainers/spark-data-flow/assets/site.js
@@ -1,0 +1,71 @@
+(function () {
+  function all(selector, root) {
+    return Array.prototype.slice.call((root || document).querySelectorAll(selector));
+  }
+
+  function setDetails(open) {
+    all("details").forEach(function (detail) {
+      detail.open = open;
+    });
+  }
+
+  function setupControls() {
+    var expand = document.querySelector("[data-expand-all]");
+    var collapse = document.querySelector("[data-collapse-all]");
+    if (expand) {
+      expand.addEventListener("click", function () {
+        setDetails(true);
+      });
+    }
+    if (collapse) {
+      collapse.addEventListener("click", function () {
+        setDetails(false);
+      });
+    }
+  }
+
+  function setupSearch() {
+    var input = document.querySelector("[data-search]");
+    var count = document.querySelector("[data-search-count]");
+    if (!input) return;
+
+    var searchable = all(".searchable");
+    function filter() {
+      var query = input.value.trim().toLowerCase();
+      var visible = 0;
+      searchable.forEach(function (item) {
+        var matches = !query || item.textContent.toLowerCase().indexOf(query) !== -1;
+        item.classList.toggle("hidden", !matches);
+        if (matches) visible += 1;
+      });
+      if (count) {
+        count.textContent = query ? visible + " matching blocks" : searchable.length + " blocks";
+      }
+    }
+    input.addEventListener("input", filter);
+    filter();
+  }
+
+  function setupFlowFocus() {
+    all("[data-flow-step]").forEach(function (step) {
+      step.addEventListener("click", function () {
+        var key = step.getAttribute("data-flow-step");
+        all("[data-flow-step]").forEach(function (item) {
+          item.classList.toggle("is-active", item.getAttribute("data-flow-step") === key);
+        });
+        all("[data-flow-target]").forEach(function (item) {
+          item.classList.toggle("is-active", item.getAttribute("data-flow-target") === key);
+          if (item.getAttribute("data-flow-target") === key && item.tagName === "DETAILS") {
+            item.open = true;
+          }
+        });
+      });
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    setupControls();
+    setupSearch();
+    setupFlowFocus();
+  });
+})();

--- a/explainers/spark-data-flow/assets/styles.css
+++ b/explainers/spark-data-flow/assets/styles.css
@@ -1,0 +1,414 @@
+:root {
+  --bg: #f6f5f2;
+  --panel: #ffffff;
+  --panel-2: #eeece6;
+  --ink: #1a1a1a;
+  --muted: #565350;
+  --line: #d4cfc4;
+  --line-strong: #a6a093;
+  --accent: #b0451c;
+  --accent-2: #1f5a7a;
+  --code-bg: #1f1f1f;
+  --code-ink: #f2f0ea;
+  --radius: 8px;
+  --space-1: 8px;
+  --space-2: 12px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 32px;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--ink);
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+a {
+  color: var(--accent);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent-2);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+  background: var(--panel-2);
+  border-right: 2px solid var(--line);
+  padding: var(--space-4);
+}
+
+.brand {
+  display: grid;
+  gap: var(--space-1);
+  margin-bottom: var(--space-4);
+}
+
+.brand strong {
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.brand span,
+.meta,
+.small {
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.nav {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.nav a {
+  display: block;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.nav a[aria-current="page"],
+.nav a:hover,
+.nav a:focus {
+  background: var(--panel);
+  outline: 2px solid var(--line-strong);
+  outline-offset: -2px;
+}
+
+.content {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--space-5);
+}
+
+.topbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-4);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+button,
+input[type="search"] {
+  min-height: 44px;
+  border: 2px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--panel);
+  color: var(--ink);
+  font: inherit;
+  padding: 9px 12px;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:hover,
+button:focus,
+input[type="search"]:focus {
+  outline: 3px solid #c4b9a7;
+  outline-offset: 2px;
+}
+
+input[type="search"] {
+  width: min(100%, 360px);
+}
+
+h1,
+h2,
+h3 {
+  line-height: 1.2;
+  letter-spacing: 0;
+  margin: 0;
+}
+
+h1 {
+  font-size: 28px;
+  margin-bottom: var(--space-3);
+}
+
+h2 {
+  font-size: 22px;
+}
+
+h3 {
+  font-size: 18px;
+}
+
+p {
+  margin: 0 0 var(--space-3);
+}
+
+.lead {
+  font-size: 18px;
+  max-width: 78ch;
+}
+
+.section {
+  margin: 0 0 var(--space-5);
+}
+
+.panel,
+details,
+.flow-step,
+.table-wrap {
+  background: var(--panel);
+  border: 2px solid var(--line);
+  border-radius: var(--radius);
+}
+
+.panel {
+  padding: var(--space-4);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.grid.three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.stack {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.flow {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.flow-step {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  text-align: left;
+  width: 100%;
+}
+
+.flow-step.is-active,
+.flow-step:hover,
+.flow-step:focus {
+  border-color: var(--line-strong);
+  background: #faf9f6;
+}
+
+.step-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  border-radius: 999px;
+  background: var(--panel-2);
+  color: var(--ink);
+  padding: 3px 10px;
+  font-size: 15px;
+  white-space: nowrap;
+}
+
+details {
+  padding: 0;
+  overflow: hidden;
+}
+
+summary {
+  cursor: pointer;
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  font-weight: 700;
+}
+
+summary::marker {
+  color: var(--accent);
+}
+
+.details-body {
+  border-top: 2px solid var(--line);
+  padding: var(--space-4);
+}
+
+pre,
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+pre {
+  margin: var(--space-3) 0 0;
+  overflow-x: auto;
+  white-space: pre;
+  background: var(--code-bg);
+  color: var(--code-ink);
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+code {
+  white-space: pre;
+}
+
+p code,
+li code,
+td code,
+summary code {
+  background: var(--panel-2);
+  color: var(--ink);
+  border-radius: 4px;
+  padding: 1px 4px;
+}
+
+ul,
+ol {
+  margin: 0;
+  padding-left: 22px;
+}
+
+li + li {
+  margin-top: var(--space-1);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+th,
+td {
+  text-align: left;
+  vertical-align: top;
+  padding: var(--space-2);
+  border-bottom: 2px solid var(--line);
+}
+
+th {
+  background: var(--panel-2);
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.callout {
+  border-left: 6px solid var(--line-strong);
+  padding: var(--space-3);
+  background: var(--panel-2);
+  border-radius: var(--radius);
+}
+
+.coderef {
+  margin-top: var(--space-3);
+  font-size: 15px;
+}
+
+.coderef a {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.footer {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 2px solid var(--line);
+  color: var(--muted);
+}
+
+@media (max-width: 860px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    border-right: 0;
+    border-bottom: 2px solid var(--line);
+    padding: var(--space-3);
+  }
+
+  .nav {
+    display: flex;
+    flex-wrap: wrap;
+    overflow-x: auto;
+    padding-bottom: var(--space-1);
+  }
+
+  .nav a {
+    flex: 0 0 auto;
+  }
+
+  .content {
+    padding: var(--space-4) var(--space-3);
+  }
+
+  .grid,
+  .grid.three {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    align-items: stretch;
+  }
+
+  .controls,
+  input[type="search"],
+  button {
+    width: 100%;
+  }
+}

--- a/explainers/spark-data-flow/components/cluster-deploy.html
+++ b/explainers/spark-data-flow/components/cluster-deploy.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cluster &amp; Deploy — Spark Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>Apache Spark Data Flow</strong>
+        <span>apache/spark @ <code>583e5bb</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="driver-and-context.html">Driver &amp; SparkContext</a>
+        <a href="rdd-and-lineage.html">RDD &amp; Lineage</a>
+        <a href="scheduler.html">DAG &amp; Task Scheduling</a>
+        <a href="execution-and-memory.html">Executor, Storage &amp; Memory</a>
+        <a href="shuffle.html">Shuffle</a>
+        <a href="spark-sql-catalyst.html">Spark SQL &amp; Catalyst</a>
+        <a href="structured-streaming.html">Structured Streaming</a>
+        <a href="cluster-deploy.html" aria-current="page">Cluster &amp; Deploy</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Deployment: how processes get placed on a cluster</h1>
+          <p class="lead">Before any scheduling happens, the driver and executor processes have to exist. <code>spark-submit</code> launches the application; a cluster manager (Standalone, YARN, or Kubernetes) places the driver and executor JVMs. This page shows the launch path and the Standalone master/worker protocol as the clearest example.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>Control plane vs. data plane, again</h2>
+        <pre><code>spark-submit
+   │ parse args, set cluster manager from master URL
+   ▼
+DRIVER (your SparkContext)
+   │ registers the application, requests executors
+   ▼
+CLUSTER MANAGER (Standalone Master / YARN RM / K8s API)
+   │ picks nodes with free resources
+   ▼
+WORKER NODES launch EXECUTOR JVMs
+   │ each executor connects back to the DRIVER
+   ▼
+DRIVER schedules tasks straight onto executors  (cluster manager steps aside)</code></pre>
+        <p>The key idea: the cluster manager only handles <em>process placement and lifecycle</em>. Once executors register with the driver, all task scheduling flows directly between driver and executors, exactly as described on the scheduling page.</p>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>spark-submit — the universal launcher</summary>
+          <div class="details-body">
+            <p><code>SparkSubmit</code> parses arguments, prepares the classpath, and dispatches based on the action (submit, kill, request status). <code>prepareSubmitEnvironment</code> reads the master URL to choose the cluster manager — <code>spark://</code> → Standalone, <code>yarn</code>, <code>k8s://</code>, or <code>local</code> — and the deploy mode. In client mode it runs your main class in the submitting JVM; in cluster mode it asks the cluster manager to launch the driver on a worker.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala#L70-L100">SparkSubmit.scala L70-L100 — doSubmit</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala#L243-L265">SparkSubmit.scala L243-L265 — choosing the cluster manager</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Client mode vs. cluster mode</summary>
+          <div class="details-body">
+            <p>In <strong>client</strong> mode the driver runs wherever you typed <code>spark-submit</code> (your laptop, an edge node); executors run on the cluster and connect back to it. This is great for interactive shells but ties the application's life to your local process. In <strong>cluster</strong> mode the driver itself is shipped to and run on a cluster node, so the application survives your client disconnecting — the right choice for production jobs.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Standalone Master — the resource broker</summary>
+          <div class="details-body">
+            <p>The Standalone <code>Master</code> is an RPC endpoint that tracks registered workers, applications, and drivers. When a driver's <code>StandaloneAppClient</code> sends <code>RegisterApplication</code>, the master records it and runs <code>schedule()</code>. <code>startExecutorsOnWorkers</code> is a simple FIFO scheduler that spreads executors across workers with free cores and memory, then <code>launchExecutor</code> sends a <code>LaunchExecutor</code> message to the chosen worker.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala#L291-L304">Master.scala L291-L304 — RegisterApplication</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala#L831-L847">Master.scala L831-L847 — startExecutorsOnWorkers</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Standalone Worker — the process launcher</summary>
+          <div class="details-body">
+            <p>A <code>Worker</code> registers its capacity with the master and waits. On <code>LaunchExecutor</code> it creates a work directory and an <code>ExecutorRunner</code> that spawns a separate <code>CoarseGrainedExecutorBackend</code> JVM; on <code>LaunchDriver</code> (cluster mode) it spawns the driver via a <code>DriverRunner</code>. The newly started executor connects back to the driver, not to the master.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala#L601-L662">Worker.scala L601-L662 — LaunchExecutor</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>How an executor joins the driver</summary>
+          <div class="details-body">
+            <p>After the master sends <code>LaunchExecutor</code>, it notifies the driver with <code>ExecutorAdded</code>. The executor process starts, registers with the driver's <code>CoarseGrainedSchedulerBackend</code>, and from then on receives <code>LaunchTask</code> messages directly. This is the seam where deployment hands off to scheduling: the same <code>CoarseGrainedExecutorBackend</code> is used regardless of whether YARN, Kubernetes, or Standalone launched it.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala#L998-L1006">Master.scala L998-L1006 — launchExecutor &amp; ExecutorAdded</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>The cluster managers compared</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>Manager</th><th>Master URL</th><th>How executors are placed</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Standalone</td><td><code>spark://host:7077</code></td><td>Spark's own Master/Worker daemons; FIFO across workers.</td></tr>
+              <tr><td>YARN</td><td><code>yarn</code></td><td>Executors run as YARN containers requested from the ResourceManager.</td></tr>
+              <tr><td>Kubernetes</td><td><code>k8s://https://...</code></td><td>Driver and executors run as pods created via the K8s API.</td></tr>
+              <tr><td>Local</td><td><code>local[*]</code></td><td>Driver and "executors" are threads in one JVM — for development.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>All four present the same <code>SchedulerBackend</code> to the rest of Spark, which is why a job written and tested with <code>local[*]</code> runs unchanged on a thousand-node YARN or Kubernetes cluster.</p>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Key takeaways</h2>
+          <ul>
+            <li><code>spark-submit</code> chooses the cluster manager from the master URL.</li>
+            <li>Client mode runs the driver locally; cluster mode ships it onto the cluster.</li>
+            <li>The cluster manager only places processes; the driver schedules tasks directly.</li>
+            <li>Executors are always <code>CoarseGrainedExecutorBackend</code> JVMs, regardless of manager.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://spark.apache.org/docs/latest/submitting-applications.html">Submitting applications</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/spark-standalone.html">Standalone mode</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/running-on-yarn.html">Running on YARN</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/running-on-kubernetes.html">Running on Kubernetes</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>Code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/spark-data-flow/components/driver-and-context.html
+++ b/explainers/spark-data-flow/components/driver-and-context.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Driver &amp; SparkContext — Spark Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>Apache Spark Data Flow</strong>
+        <span>apache/spark @ <code>583e5bb</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="driver-and-context.html" aria-current="page">Driver &amp; SparkContext</a>
+        <a href="rdd-and-lineage.html">RDD &amp; Lineage</a>
+        <a href="scheduler.html">DAG &amp; Task Scheduling</a>
+        <a href="execution-and-memory.html">Executor, Storage &amp; Memory</a>
+        <a href="shuffle.html">Shuffle</a>
+        <a href="spark-sql-catalyst.html">Spark SQL &amp; Catalyst</a>
+        <a href="structured-streaming.html">Structured Streaming</a>
+        <a href="cluster-deploy.html">Cluster &amp; Deploy</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>The driver: SparkConf, SparkContext, SparkEnv</h1>
+          <p class="lead">The driver is the process that runs your program. Before any data moves, it must build a runtime: configuration is frozen, shared services are created, and the scheduler stack is wired up. This page follows the boot sequence and shows what each object is responsible for.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>Boot sequence at a glance</h2>
+        <pre><code>new SparkConf()                      // 1. read spark.* settings
+      │
+      ▼
+new SparkContext(conf)               // 2. the driver comes alive
+      │
+      ├─► createSparkEnv(...)         //    SparkEnv: serializer, blockManager,
+      │                              //    mapOutputTracker, broadcastManager
+      │
+      ├─► initializeShuffleManager()  //    deferred so plugins can customize
+      ├─► initializeMemoryManager()
+      │
+      ├─► createTaskScheduler(master) // 3. backend + TaskSchedulerImpl
+      ├─► new DAGScheduler(this)
+      │
+      └─► taskScheduler.start()       // 4. backend registers, app gets an id</code></pre>
+        <p>Everything below the constructor happens once, eagerly, inside the <code>SparkContext</code> initialization block. After it returns, the application is ready to build RDDs and run jobs.</p>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>SparkConf — the frozen configuration</summary>
+          <div class="details-body">
+            <p><code>SparkConf</code> is a simple key/value store. Calling <code>new SparkConf()</code> loads every <code>spark.*</code> property from the JVM system properties. Once it is handed to a <code>SparkContext</code>, the context clones it, so later mutations to your original object have no effect — configuration is effectively immutable for the life of the application.</p>
+            <p>This is why settings such as <code>spark.executor.memory</code> or <code>spark.sql.shuffle.partitions</code> must be set before the context is created.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkConf.scala#L287-L296">SparkConf.scala L287-L296 — class and default constructor</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>SparkContext — the entry point</summary>
+          <div class="details-body">
+            <p>The class doc calls it "the main entry point for Spark functionality" — the connection to a cluster used to create RDDs, accumulators, and broadcast variables. Only one active <code>SparkContext</code> may exist per JVM.</p>
+            <p>Its constructor declares four runtime pillars as private fields — <code>_env</code>, <code>_schedulerBackend</code>, <code>_taskScheduler</code>, <code>_dagScheduler</code> — and fills them in during initialization. Holding these references is what makes the context the hub of the whole system.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkContext.scala#L86">SparkContext.scala L86 — class definition</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkContext.scala#L220-L229">SparkContext.scala L220-L229 — the runtime fields</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>SparkEnv — the shared service container</summary>
+          <div class="details-body">
+            <p><code>SparkEnv</code> "holds all the runtime environment objects for a running Spark instance." A single instance exists per process (driver or executor) and is reachable from anywhere via the global <code>SparkEnv.get</code>. This is how task code running deep inside an RDD can reach the local <code>BlockManager</code> without threading references through every call.</p>
+            <p>It bundles the serializer, the closure serializer, the <code>BlockManager</code>, the <code>MapOutputTracker</code> (a <em>master</em> on the driver, a <em>worker</em> on executors), the broadcast manager, and lazily-initialized shuffle and memory managers.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkEnv.scala#L64-L76">SparkEnv.scala L64-L76 — the held components</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkEnv.scala#L331-L360">SparkEnv.scala L331-L360 — createDriverEnv</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Why shuffle and memory managers initialize late</summary>
+          <div class="details-body">
+            <p>Notice that <code>SparkEnv</code> creates the shuffle and memory managers <em>after</em> the rest of the environment, through <code>initializeShuffleManager()</code> and <code>initializeMemoryManager(...)</code>. This deferral lets user JARs and plugins register custom implementations (for example, a custom <code>ShuffleManager</code>) before they are instantiated.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkContext.scala#L596-L597">SparkContext.scala L596-L597 — deferred init calls</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkEnv.scala#L293-L308">SparkEnv.scala L293-L308 — initialize methods</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>createTaskScheduler — one code path, many cluster managers</summary>
+          <div class="details-body">
+            <p>This factory pattern-matches on the master URL and returns a <code>(SchedulerBackend, TaskScheduler)</code> pair. <code>local[*]</code> yields a <code>LocalSchedulerBackend</code>; <code>spark://</code> yields a <code>StandaloneSchedulerBackend</code>; YARN and Kubernetes are loaded through the <code>ExternalClusterManager</code> service-provider interface. The rest of Spark is written against the <code>SchedulerBackend</code> trait, so the same scheduling logic runs unchanged everywhere.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkContext.scala#L3295-L3399">SparkContext.scala L3295-L3399 — createTaskScheduler</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>runJob — the bridge from your code to the cluster</summary>
+          <div class="details-body">
+            <p>Every action ends here. <code>runJob</code> takes a target RDD, a function to run on each partition, the set of partition indices, and a result handler. It cleans the closure (so it can be serialized and shipped), records the call site for the UI, and delegates to <code>dagScheduler.runJob</code>. After the job finishes it triggers any pending checkpointing.</p>
+            <pre><code>def runJob[T, U](rdd, func, partitions, resultHandler): Unit = {
+  val cleanedFunc = clean(func)            // make the closure shippable
+  dagScheduler.runJob(rdd, cleanedFunc,    // hand off to the DAG scheduler
+                      partitions, callSite, resultHandler, ...)
+  rdd.doCheckpoint()                       // materialize checkpoints if any
+}</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkContext.scala#L2481-L2499">SparkContext.scala L2481-L2499 — runJob</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>How the pieces relate</h2>
+        <p>The driver is a single JVM, but it holds several long-lived collaborators. The <code>SparkContext</code> owns them; <code>SparkEnv</code> makes the stateless services globally reachable; the scheduler trio coordinates execution.</p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>Object</th><th>Lives on</th><th>Responsibility</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>SparkContext</code></td><td>Driver only</td><td>User API surface; owns the scheduler stack and tracks jobs.</td></tr>
+              <tr><td><code>SparkEnv</code></td><td>Driver and every executor</td><td>Shared services (serializer, block manager, trackers) via <code>SparkEnv.get</code>.</td></tr>
+              <tr><td><code>DAGScheduler</code></td><td>Driver only</td><td>Plans stages from RDD lineage; covered on the scheduling page.</td></tr>
+              <tr><td><code>TaskSchedulerImpl</code></td><td>Driver only</td><td>Assigns tasks to executor offers.</td></tr>
+              <tr><td><code>SchedulerBackend</code></td><td>Driver only</td><td>Talks to the cluster manager and to executors.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Key takeaways</h2>
+          <ul>
+            <li>Configuration is frozen at context creation; set <code>spark.*</code> properties first.</li>
+            <li><code>SparkEnv.get</code> is the back-channel that lets remote task code reach local services.</li>
+            <li>One factory (<code>createTaskScheduler</code>) hides all cluster-manager differences.</li>
+            <li><code>SparkContext.runJob</code> is the single funnel for every action.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://spark.apache.org/docs/latest/rdd-programming-guide.html#initializing-spark">Initializing Spark (SparkContext)</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/configuration.html">Spark configuration reference</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/cluster-overview.html">Cluster mode overview</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>Code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/spark-data-flow/components/execution-and-memory.html
+++ b/explainers/spark-data-flow/components/execution-and-memory.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Executor, Storage &amp; Memory — Spark Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>Apache Spark Data Flow</strong>
+        <span>apache/spark @ <code>583e5bb</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="driver-and-context.html">Driver &amp; SparkContext</a>
+        <a href="rdd-and-lineage.html">RDD &amp; Lineage</a>
+        <a href="scheduler.html">DAG &amp; Task Scheduling</a>
+        <a href="execution-and-memory.html" aria-current="page">Executor, Storage &amp; Memory</a>
+        <a href="shuffle.html">Shuffle</a>
+        <a href="spark-sql-catalyst.html">Spark SQL &amp; Catalyst</a>
+        <a href="structured-streaming.html">Structured Streaming</a>
+        <a href="cluster-deploy.html">Cluster &amp; Deploy</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Executors: running tasks, storing blocks, managing memory</h1>
+          <p class="lead">An executor is a JVM that does the actual work. It receives tasks, runs them on a thread pool, serves and caches data through its <code>BlockManager</code>, and shares a fixed memory budget between computation and storage. This page follows a task into an executor and explains the unified memory model.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>What happens when a task lands</h2>
+        <pre><code>(RPC) LaunchTask
+   │
+   ▼
+CoarseGrainedExecutorBackend.receive  → decode TaskDescription
+   │
+   ▼
+Executor.launchTask  → new TaskRunner → threadPool.execute
+   │
+   ▼
+TaskRunner.run
+   ├─ report TaskState.RUNNING
+   ├─ updateDependencies (fetch jars/files)
+   ├─ deserialize the Task with closureSerializer
+   ├─ task.run(...)              ◄── calls RDD.iterator / shuffle writer
+   ├─ serialize the result
+   └─ statusUpdate(FINISHED, result)   (inline, or via BlockManager if large)</code></pre>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>CoarseGrainedExecutorBackend — the RPC endpoint</summary>
+          <div class="details-body">
+            <p>This is the object the driver talks to. On <code>RegisteredExecutor</code> it creates the <code>Executor</code>; on <code>LaunchTask</code> it decodes the serialized <code>TaskDescription</code> and calls <code>executor.launchTask</code>; and it forwards every task <code>statusUpdate</code> back to the driver. It is the thin networking shell around the real worker.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala#L167-L188">CoarseGrainedExecutorBackend.scala L167-L188 — receiving LaunchTask</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Executor and TaskRunner — the work loop</summary>
+          <div class="details-body">
+            <p>The <code>Executor</code> owns a cached thread pool, the <code>BlockManager</code>, and a heartbeat loop. Each task becomes a <code>TaskRunner</code> (a <code>Runnable</code>) submitted to the pool, so an executor runs as many concurrent tasks as it has cores. <code>launchTask</code> registers the runner in <code>runningTasks</code> and submits it.</p>
+            <p>Inside <code>TaskRunner.run</code>, the task binary is deserialized, the actual computation is invoked, and block locks plus task memory are released in a <code>finally</code> block no matter what.</p>
+            <pre><code>val value = Utils.tryWithSafeFinally {
+  task.run(taskAttemptId = taskId, attemptNumber = ...,
+           metricsSystem = env.metricsSystem, ...)
+} {
+  env.blockManager.releaseAllLocksForTask(taskId)   // always runs
+}</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/executor/Executor.scala#L551-L601">Executor.scala L551-L601 — launchTask</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/executor/Executor.scala#L849-L896">Executor.scala L849-L896 — deserialize &amp; run</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Returning results and heartbeats</summary>
+          <div class="details-body">
+            <p>Small results travel inline in the status update. If a result exceeds <code>spark.task.maxDirectResultSize</code> it is stored in the <code>BlockManager</code> and only an <code>IndirectTaskResult</code> handle is sent; if it exceeds <code>spark.driver.maxResultSize</code> it is dropped with an error. Meanwhile a periodic heartbeat reports liveness and per-task metrics to the driver's <code>HeartbeatReceiver</code>; repeated heartbeat failures cause the executor to exit.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/executor/Executor.scala#L940-L1029">Executor.scala L940-L1029 — result delivery</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/executor/Executor.scala#L1518-L1565">Executor.scala L1518-L1565 — reportHeartBeat</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>BlockManager — the per-node data service</summary>
+          <div class="details-body">
+            <p>A <code>BlockManager</code> runs on every node and is the universal data layer: it stores cached RDD partitions, broadcast variables, and shuffle blocks, serving them locally or fetching them from peers. <code>get</code> tries the local memory store, then the local disk store, then remote nodes. <code>put</code> writes to memory first and spills to disk when configured. A driver-side <code>BlockManagerMaster</code> tracks where every block lives cluster-wide.</p>
+            <pre><code>get(blockId)  = getLocalValues  orElse  getRemoteValues
+putIterator   → doPutIterator → memory first, then disk if allowed</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala#L182-L194">BlockManager.scala L182-L194 — class</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala#L1347-L1359">BlockManager.scala L1347-L1359 — get</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Unified memory: execution and storage share one pool</summary>
+          <div class="details-body">
+            <p>The <code>UnifiedMemoryManager</code> draws a <em>soft</em> boundary between two kinds of memory. <strong>Execution memory</strong> is used transiently for shuffles, joins, sorts, and aggregations. <strong>Storage memory</strong> holds cached blocks. Either side can borrow from the other when it has spare capacity — with one asymmetry: storage that has borrowed execution memory can be evicted when execution needs it back, but execution memory is never evicted by storage.</p>
+            <p>The source comment states the defaults exactly:</p>
+            <pre><code>shared region = (heap - 300MB) * spark.memory.fraction      // default 0.6
+storage region within it      * spark.memory.storageFraction // default 0.5
+⇒ storage ≈ 0.6 * 0.5 = 0.3 of the heap by default
+   300MB is RESERVED_SYSTEM_MEMORY_BYTES</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala#L34-L57">UnifiedMemoryManager.scala L34-L57 — the model and fractions</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala#L134-L248">UnifiedMemoryManager.scala L134-L248 — acquireExecution / acquireStorage</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>MemoryStore and DiskStore — the two tiers</summary>
+          <div class="details-body">
+            <p>The <code>MemoryStore</code> keeps blocks in a <code>LinkedHashMap</code> (so eviction is LRU) as either deserialized object arrays or serialized byte buffers. It "unrolls" an iterator gradually, requesting more memory as it goes, so a single huge partition cannot blow the heap. When memory is tight, the eviction handler spills blocks to the <code>DiskStore</code>, which writes them to local files via the <code>DiskBlockManager</code>. This memory-then-disk tiering is exactly what storage levels like <code>MEMORY_AND_DISK</code> select.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala#L82-L88">MemoryStore.scala L82-L88 — class</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala#L190-L248">MemoryStore.scala L190-L248 — putIterator unrolling</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala#L45-L115">DiskStore.scala L45-L115 — disk persistence</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>The memory budget, visualized</h2>
+        <pre><code>┌──────────────────────────── executor JVM heap ───────────────────────────┐
+│ reserved 300MB │            spark.memory.fraction = 0.6 of (heap-300MB)    │
+│  (system)      │  ┌───────────────────────────┬─────────────────────────┐ │
+│                │  │   storage (cache blocks)   │   execution (shuffle,   │ │
+│                │  │   storageFraction = 0.5    │   sort, join, agg)      │ │
+│                │  └───────────────────────────┴─────────────────────────┘ │
+│                │       ◄── soft, borrowable boundary ──►                   │
+│   user memory (objects you allocate) = remaining ~0.4 of (heap-300MB)      │
+└───────────────────────────────────────────────────────────────────────────┘</code></pre>
+        <p>Spilling is normal and healthy: when execution memory is exhausted, sorts and aggregations spill sorted runs to disk rather than failing. Frequent spilling is the signal to add memory or partitions.</p>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Key takeaways</h2>
+          <ul>
+            <li>An executor runs one <code>TaskRunner</code> per core on a shared thread pool.</li>
+            <li>The <code>BlockManager</code> is the single store for cache, broadcast, and shuffle blocks.</li>
+            <li>Execution and storage share one budget; storage is evictable, execution is not.</li>
+            <li>Caching tiers through memory then disk; spilling to disk prevents out-of-memory failures.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://spark.apache.org/docs/latest/tuning.html#memory-management-overview">Memory management overview</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/configuration.html#memory-management">Memory configuration</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence">Storage levels</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>Code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/spark-data-flow/components/rdd-and-lineage.html
+++ b/explainers/spark-data-flow/components/rdd-and-lineage.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RDD &amp; Lineage — Spark Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>Apache Spark Data Flow</strong>
+        <span>apache/spark @ <code>583e5bb</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="driver-and-context.html">Driver &amp; SparkContext</a>
+        <a href="rdd-and-lineage.html" aria-current="page">RDD &amp; Lineage</a>
+        <a href="scheduler.html">DAG &amp; Task Scheduling</a>
+        <a href="execution-and-memory.html">Executor, Storage &amp; Memory</a>
+        <a href="shuffle.html">Shuffle</a>
+        <a href="spark-sql-catalyst.html">Spark SQL &amp; Catalyst</a>
+        <a href="structured-streaming.html">Structured Streaming</a>
+        <a href="cluster-deploy.html">Cluster &amp; Deploy</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>RDDs: the lineage that defines a computation</h1>
+          <p class="lead">The Resilient Distributed Dataset is Spark's foundational abstraction. Even DataFrames and SQL ultimately compile down to RDDs. Understanding the five properties, the lazy graph they form, and the difference between narrow and wide dependencies explains almost everything about how Spark schedules and recovers work.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>An RDD is a recipe, not a table</h2>
+        <p>An RDD does not hold data. It is an immutable description of <em>how to compute</em> a partitioned collection from its parents. The source comment lists the five properties that every RDD answers; all scheduling decisions are derived from them.</p>
+        <pre><code>Internally, each RDD is characterized by five main properties:
+
+  - A list of partitions                       getPartitions
+  - A function for computing each split         compute(partition, ctx)
+  - A list of dependencies on other RDDs        getDependencies
+  - Optionally, a Partitioner for key-value     partitioner
+  - Optionally, preferred locations per split   getPreferredLocations</code></pre>
+        <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L69-L83">RDD.scala L69-L83 — the five properties</a></p>
+        <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L84-L139">RDD.scala L84-L139 — the abstract class and the five methods/fields</a></p>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Lineage: a chain of small wrappers</h2>
+        <pre><code>sc.textFile("data")        HadoopRDD          partitions = HDFS splits
+   .map(parse)        →    MapPartitionsRDD   OneToOneDependency
+   .filter(valid)     →    MapPartitionsRDD   OneToOneDependency
+   .map(toPair)       →    MapPartitionsRDD   OneToOneDependency
+   .reduceByKey(_+_)  →    ShuffledRDD        ShuffleDependency  ◄── stage boundary
+   .collect()              ACTION             triggers a job</code></pre>
+        <p>Each transformation returns a new RDD that points back at its parent. The arrows are <code>Dependency</code> objects. A single-parent RDD gets a <code>OneToOneDependency</code> automatically through the convenience constructor.</p>
+        <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L102-L104">RDD.scala L102-L104 — one-to-one parent constructor</a></p>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>Transformations build the graph (lazy)</summary>
+          <div class="details-body">
+            <p>A transformation never touches data on the cluster. <code>map</code> cleans the user function and wraps the parent in a <code>MapPartitionsRDD</code> whose <code>compute</code> simply applies <code>iter.map(cleanF)</code> to the parent's iterator. Because the new RDD keeps the same number of partitions and depends one-to-one on its parent, it can be pipelined with neighbours into a single stage.</p>
+            <pre><code>def map[U](f: T =&gt; U): RDD[U] = {
+  val cleanF = sc.clean(f)
+  new MapPartitionsRDD[U, T](this,
+    (context, pid, iter) =&gt; iter.map(cleanF))
+}</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L424-L450">RDD.scala L424-L450 — map and filter</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Actions launch jobs (eager)</summary>
+          <div class="details-body">
+            <p>Actions are the only operations that cross the driver boundary. <code>collect</code> runs a job that turns each partition into an array and concatenates them on the driver; <code>count</code> sums per-partition sizes; <code>reduce</code> merges per-partition reductions. All of them call <code>sc.runJob</code>.</p>
+            <pre><code>def collect(): Array[T] = {
+  val results = sc.runJob(this, iter =&gt; iter.toArray)
+  Array.concat(results: _*)
+}</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L1072-L1076">RDD.scala L1072-L1076 — collect</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L1146-L1167">RDD.scala L1146-L1167 — reduce</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Narrow vs. shuffle dependencies</summary>
+          <div class="details-body">
+            <p>The <code>Dependency</code> type is the single most important fact about an RDD edge. A <code>NarrowDependency</code> means each child partition needs only a few specific parent partitions, so the work can be pipelined locally. A <code>ShuffleDependency</code> means a child partition may need data from <em>every</em> parent partition, which requires a network exchange and forces a stage boundary.</p>
+            <pre><code>NarrowDependency.getParents(childPartitionId): Seq[Int]
+  // OneToOneDependency: child i ← parent i  (map, filter)
+  // RangeDependency:    contiguous ranges    (union)
+
+ShuffleDependency
+  // registers a shuffleId + shuffleHandle with the ShuffleManager
+  // carries the Partitioner that decides the reducer for each key</code></pre>
+            <p>Creating a <code>ShuffleDependency</code> immediately registers the shuffle with the shuffle manager, allocating a <code>shuffleId</code> — the shuffle is "planned" the moment the lineage is built, even though no bytes move until execution.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/Dependency.scala#L46-L61">Dependency.scala L46-L61 — NarrowDependency</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/Dependency.scala#L83-L138">Dependency.scala L83-L138 — ShuffleDependency and shuffle registration</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Partitions and the Partitioner</summary>
+          <div class="details-body">
+            <p>A <code>Partition</code> is just a serializable index identifying one slice of an RDD; it is the unit of task parallelism. For key/value RDDs, a <code>Partitioner</code> maps each key to a partition id and therefore decides how many reducers a shuffle has and where each key lands. <code>HashPartitioner</code> (the default) uses <code>key.hashCode mod numPartitions</code>; <code>RangePartitioner</code> samples the data to build sorted bounds for <code>sortByKey</code>.</p>
+            <p>Choosing a good partitioner is the main lever for avoiding skew and unnecessary shuffles: if two RDDs already share a partitioner, a join between them can be narrow.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/Partition.scala#L23-L33">Partition.scala L23-L33 — the Partition trait</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/Partitioner.scala#L114-L132">Partitioner.scala L114-L132 — HashPartitioner</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>iterator: compute, cache, or checkpoint</summary>
+          <div class="details-body">
+            <p>When a task needs a partition it calls <code>RDD.iterator</code>. This is the decision point between recomputation and reuse: if the RDD is persisted, it goes through <code>getOrCompute</code> (which asks the local <code>BlockManager</code> for a cached block, computing and storing it on a miss); otherwise it calls <code>computeOrReadCheckpoint</code>, which either reads a materialized checkpoint or finally calls the subclass's <code>compute</code>.</p>
+            <pre><code>final def iterator(split, context): Iterator[T] =
+  if (storageLevel != NONE) getOrCompute(split, context)   // cache path
+  else                      computeOrReadCheckpoint(split, context)</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L334-L409">RDD.scala L334-L409 — iterator, computeOrReadCheckpoint, getOrCompute</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>persist / cache and fault tolerance</summary>
+          <div class="details-body">
+            <p><code>cache()</code> is <code>persist(MEMORY_ONLY)</code>. Persisting only sets a storage level and registers the RDD with the context; the data is materialized the first time a partition is computed, after which <code>getOrCompute</code> finds it in the block manager. Lineage is what makes this safe: if a cached partition is lost, Spark recomputes it from its parents rather than failing the job. This recompute-from-lineage property is the "Resilient" in RDD.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L186-L205">RDD.scala L186-L205 — persist and cache</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Why this matters downstream</h2>
+        <p>The lineage graph is the input to the <code>DAGScheduler</code>. It walks dependencies backward from the action: narrow edges are folded into the current stage, and every shuffle edge becomes a boundary. So the way you write transformations — particularly which ones introduce shuffles — directly determines the number of stages, the amount of network traffic, and the recovery behaviour of your job. Continue to <a href="scheduler.html">DAG &amp; Task Scheduling</a> to see the graph become stages and tasks.</p>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Key takeaways</h2>
+          <ul>
+            <li>An RDD stores a recipe (five properties), not data.</li>
+            <li>Transformations are lazy graph-building; actions are eager and call <code>runJob</code>.</li>
+            <li>Narrow dependencies pipeline; shuffle dependencies create stage boundaries.</li>
+            <li>The partitioner controls reducer count, key placement, and shuffle-free joins.</li>
+            <li>Lineage enables recomputation, which is Spark's fault-tolerance mechanism.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://people.csail.mit.edu/matei/papers/2012/nsdi_spark.pdf">RDD paper (NSDI 2012)</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/rdd-programming-guide.html#resilient-distributed-datasets-rdds">RDD programming guide</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence">RDD persistence levels</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>Code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/spark-data-flow/components/scheduler.html
+++ b/explainers/spark-data-flow/components/scheduler.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DAG &amp; Task Scheduling — Spark Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>Apache Spark Data Flow</strong>
+        <span>apache/spark @ <code>583e5bb</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="driver-and-context.html">Driver &amp; SparkContext</a>
+        <a href="rdd-and-lineage.html">RDD &amp; Lineage</a>
+        <a href="scheduler.html" aria-current="page">DAG &amp; Task Scheduling</a>
+        <a href="execution-and-memory.html">Executor, Storage &amp; Memory</a>
+        <a href="shuffle.html">Shuffle</a>
+        <a href="spark-sql-catalyst.html">Spark SQL &amp; Catalyst</a>
+        <a href="structured-streaming.html">Structured Streaming</a>
+        <a href="cluster-deploy.html">Cluster &amp; Deploy</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Scheduling: job → stages → tasks → executors</h1>
+          <p class="lead">Two schedulers cooperate. The <code>DAGScheduler</code> is high-level and stage-oriented: it turns a lineage graph into a DAG of stages. The <code>TaskScheduler</code> is low-level: it places individual tasks onto executor cores with locality and retries. This page follows a job through both.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>The scheduling pipeline</h2>
+        <pre><code>action → sc.runJob
+   │
+   ▼
+DAGScheduler.submitJob  ──► event loop ──► handleJobSubmitted
+   │                                            │
+   │   createResultStage + ancestor ShuffleMapStages (split at shuffles)
+   │                                            ▼
+   │                                        submitStage  (parents first)
+   │                                            ▼
+   │                                       submitMissingTasks
+   │                                            │  builds ShuffleMapTask / ResultTask
+   ▼                                            ▼
+TaskSchedulerImpl.submitTasks  ──►  TaskSetManager (one per stage attempt)
+   │
+   ▼
+SchedulerBackend.reviveOffers ──► resourceOffers ──► launchTasks ──► EXECUTOR
+   ▲                                                                     │
+   └──────────────── statusUpdate / taskEnded ◄──────────────────────────┘</code></pre>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>DAGScheduler — the stage-oriented planner</summary>
+          <div class="details-body">
+            <p>The class doc describes it precisely: it "computes a DAG of stages for each job, keeps track of which RDDs and stage outputs are materialized, and finds a minimal schedule." It also chooses preferred locations for tasks based on cache and shuffle-output placement. It runs on a single-threaded event loop, so all scheduling state mutations are serialized and free of locks.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L58-L72">DAGScheduler.scala L58-L72 — role &amp; stage boundaries</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L124-L132">DAGScheduler.scala L124-L132 — class definition</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>submitJob is asynchronous; runJob blocks</summary>
+          <div class="details-body">
+            <p><code>submitJob</code> validates the partitions, assigns a job id, posts a <code>JobSubmitted</code> event to the event loop, and immediately returns a <code>JobWaiter</code>. <code>runJob</code> is a thin wrapper that calls <code>submitJob</code> and then blocks on that waiter, re-throwing any failure with the driver's stack trace attached. This separation lets the event loop process scheduling decisions without holding up the calling thread.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L984-L1027">DAGScheduler.scala L984-L1027 — submitJob</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L1043-L1067">DAGScheduler.scala L1043-L1067 — runJob</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Splitting the graph into stages</summary>
+          <div class="details-body">
+            <p><code>handleJobSubmitted</code> builds a <code>ResultStage</code> for the action. To find its parents, the scheduler walks the RDD graph: when it hits a <code>ShuffleDependency</code> it records a parent-stage boundary and creates (or reuses) a <code>ShuffleMapStage</code> for that shuffle; narrow dependencies are followed straight through. Stages keyed by shuffle id are shared across jobs, so a reused shuffle is not recomputed.</p>
+            <pre><code>getShuffleDependenciesAndResourceProfiles(rdd):
+  for each dependency while walking up the graph:
+    case shuffleDep: ShuffleDependency =&gt; record as parent boundary
+    case narrowDep:  NarrowDependency  =&gt; keep walking up</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L801-L815">DAGScheduler.scala L801-L815 — finding shuffle boundaries</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L528-L603">DAGScheduler.scala L528-L603 — getOrCreate / createShuffleMapStage</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>ResultStage vs. ShuffleMapStage</summary>
+          <div class="details-body">
+            <p>Every job is exactly one <code>ResultStage</code> plus zero or more ancestor <code>ShuffleMapStage</code>s. A <code>ResultStage</code> carries the action's function and the partition indices to compute; finishing all its tasks completes the job. A <code>ShuffleMapStage</code> is intermediate: its tasks write shuffle map output, and it is "available" only when every partition's output has been registered with the <code>MapOutputTracker</code> — not merely when its tasks finish.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/ResultStage.scala#L30-L65">ResultStage.scala L30-L65</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapStage.scala#L37-L96">ShuffleMapStage.scala L37-L96</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>submitMissingTasks — stage becomes a TaskSet</summary>
+          <div class="details-body">
+            <p>Once a stage's parents are available, this method asks which partitions are still missing, computes preferred locations for each, serializes the task binary — <code>(rdd, shuffleDep)</code> for a map stage or <code>(rdd, func)</code> for a result stage — and constructs one <code>ShuffleMapTask</code> or <code>ResultTask</code> per partition. It then calls <code>taskScheduler.submitTasks(new TaskSet(...))</code>.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L1635-L1845">DAGScheduler.scala L1635-L1845 — submitMissingTasks</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>The two task kinds</summary>
+          <div class="details-body">
+            <p>A <code>ShuffleMapTask</code> runs on a map stage: it iterates its partition and writes the records out through the shuffle writer, returning a <code>MapStatus</code> (block location and per-partition sizes). A <code>ResultTask</code> runs on the final stage: it applies <code>func(context, rdd.iterator(...))</code> and returns the value to the driver. Both extend <code>Task</code>, whose <code>run</code> sets up the <code>TaskContext</code> and memory manager before calling the subclass's <code>runTask</code>.</p>
+            <pre><code>Task.run        // sets TaskContext, memory, then →
+  ShuffleMapTask.runTask  → writes shuffle data → MapStatus
+  ResultTask.runTask      → func(ctx, rdd.iterator) → result value</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/Task.scala#L34-L43">Task.scala L34-L43 — the two kinds</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala#L82-L112">ShuffleMapTask.scala L82-L112 — runTask</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala#L78-L94">ResultTask.scala L78-L94 — runTask</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>TaskSchedulerImpl.resourceOffers — placing tasks</summary>
+          <div class="details-body">
+            <p>The backend periodically presents <code>WorkerOffer</code>s (executor id, host, free cores). <code>resourceOffers</code> is the core assignment routine: it registers new executors, filters unhealthy ones, sorts the active task sets by scheduling pool priority (FIFO or fair), and for each task set walks locality levels — <code>PROCESS_LOCAL → NODE_LOCAL → NO_PREF → RACK_LOCAL → ANY</code> — handing offers to the <code>TaskSetManager</code> until they are full. It returns a list of <code>TaskDescription</code>s grouped per executor.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala#L243-L285">TaskSchedulerImpl.scala L243-L285 — submitTasks</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala#L512-L520">TaskSchedulerImpl.scala L512-L520 — resourceOffers</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>TaskSetManager — locality, delay scheduling, retries</summary>
+          <div class="details-body">
+            <p>One <code>TaskSetManager</code> owns a single stage attempt. It buckets pending tasks by executor, host, and rack so it can answer offers at the tightest possible locality. <strong>Delay scheduling</strong> means it will briefly reject a less-local offer, waiting for a better one, before falling back. On failure it retries a task up to <code>maxTaskFailures</code> times by re-queuing it; a <code>FetchFailed</code> is special — it makes the set a "zombie" and lets the <code>DAGScheduler</code> resubmit the whole map stage.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala#L40-L61">TaskSetManager.scala L40-L61 — role &amp; class</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala#L461-L525">TaskSetManager.scala L461-L525 — resourceOffer / delay scheduling</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>SchedulerBackend — launching on executors</summary>
+          <div class="details-body">
+            <p>The <code>CoarseGrainedSchedulerBackend</code> keeps a registry of live executors. <code>reviveOffers</code> (called from <code>submitTasks</code> and on a timer) triggers <code>makeOffers</code>, which builds a <code>WorkerOffer</code> per executor, calls <code>resourceOffers</code>, and then <code>launchTasks</code>. <code>launchTasks</code> reserves cores on the executor's record and sends a <code>LaunchTask</code> RPC carrying the serialized <code>TaskDescription</code>. When a task finishes, the status update frees those cores and re-offers them.</p>
+            <pre><code>submitTasks → reviveOffers → makeOffers → resourceOffers
+            → launchTasks → (RPC) LaunchTask → executor</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala#L372-L456">CoarseGrainedSchedulerBackend.scala L372-L456 — makeOffers &amp; launchTasks</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Completion, the MapOutputTracker, and recovery</summary>
+          <div class="details-body">
+            <p>When a <code>ShuffleMapTask</code> succeeds, the <code>DAGScheduler</code> registers its <code>MapStatus</code> with the <code>MapOutputTrackerMaster</code>; when the whole map stage finishes it bumps the tracker's epoch and submits the waiting child stages. If a reduce task reports a <code>FetchFailed</code>, the scheduler unregisters the lost map outputs and resubmits both the failed map stage and the stage that depends on it. The epoch number stamped on every task lets stale completions from before a failure be ignored.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L2955-L2985">DAGScheduler.scala L2955-L2985 — map stage completion</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L2395-L2518">DAGScheduler.scala L2395-L2518 — FetchFailed handling</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Who owns what</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>Layer</th><th>Owns</th><th>Hands off</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>DAGScheduler</code></td><td>Job DAG, stage boundaries, shuffle bookkeeping, stage retries</td><td>A <code>TaskSet</code> per ready stage</td></tr>
+              <tr><td><code>TaskSchedulerImpl</code></td><td>Task-set priority, executor offers, within-stage task retries</td><td><code>TaskDescription</code> lists</td></tr>
+              <tr><td><code>TaskSetManager</code></td><td>Per-stage task state, locality, speculation</td><td>Serialized task + launch metadata</td></tr>
+              <tr><td><code>SchedulerBackend</code></td><td>Executor registry, RPC to executors</td><td><code>LaunchTask</code> messages</td></tr>
+              <tr><td><code>MapOutputTracker</code></td><td>Shuffle output locations and the epoch</td><td>Lookups for reduce-side fetch</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Key takeaways</h2>
+          <ul>
+            <li>Stages are cut at shuffle boundaries; the last stage of a job is always a <code>ResultStage</code>.</li>
+            <li>A map stage is "done" only when its outputs are registered, not when its tasks return.</li>
+            <li>Locality and delay scheduling try hard to run a task where its data already lives.</li>
+            <li>Within-stage retries are the <code>TaskSetManager</code>'s job; stage-level retries are the <code>DAGScheduler</code>'s.</li>
+            <li>The map output tracker's epoch is the clock that makes fault recovery consistent.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://spark.apache.org/docs/latest/job-scheduling.html">Job scheduling guide</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/tuning.html#data-locality">Data locality</a></li>
+            <li><a href="https://www.eecs.berkeley.edu/Pubs/TechRpts/2013/EECS-2013-235.html">Delay scheduling (Zaharia et al.)</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>Code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/spark-data-flow/components/shuffle.html
+++ b/explainers/spark-data-flow/components/shuffle.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Shuffle — Spark Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>Apache Spark Data Flow</strong>
+        <span>apache/spark @ <code>583e5bb</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="driver-and-context.html">Driver &amp; SparkContext</a>
+        <a href="rdd-and-lineage.html">RDD &amp; Lineage</a>
+        <a href="scheduler.html">DAG &amp; Task Scheduling</a>
+        <a href="execution-and-memory.html">Executor, Storage &amp; Memory</a>
+        <a href="shuffle.html" aria-current="page">Shuffle</a>
+        <a href="spark-sql-catalyst.html">Spark SQL &amp; Catalyst</a>
+        <a href="structured-streaming.html">Structured Streaming</a>
+        <a href="cluster-deploy.html">Cluster &amp; Deploy</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Shuffle: the all-to-all data exchange</h1>
+          <p class="lead">A shuffle is how data moves between stages when a child partition depends on many parent partitions — the work behind <code>reduceByKey</code>, <code>groupBy</code>, <code>join</code>, and repartitioning. It is the most expensive operation in Spark, so its design (sort-based, file-backed, location-tracked) is worth understanding in detail.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>Map side writes, reduce side fetches</h2>
+        <pre><code>MAP STAGE (M tasks)                      REDUCE STAGE (R tasks)
+each map task:                           each reduce task r:
+  sort records by target partition         ask MapOutputTracker:
+  write ONE data file + ONE index file       "where are blocks for partition r?"
+  data: [part0][part1]...[partR-1]         fetch contiguous byte ranges from
+  index: byte offsets of each part           every map output (local + remote)
+  report MapStatus to driver               merge / aggregate the fetched records
+
+        map output file (per map task)
+        ┌──────┬──────┬──────┬──────┐      reduce task r reads the r-th slice
+        │ p0   │ p1   │ p2   │ p3   │ ───► from each map file using the index
+        └──────┴──────┴──────┴──────┘</code></pre>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>ShuffleManager — the pluggable interface</summary>
+          <div class="details-body">
+            <p>The <code>ShuffleManager</code> trait is the contract between the engine and a shuffle implementation, selected by <code>spark.shuffle.manager</code> and created on both driver and executors. The driver <code>registerShuffle</code>s; map tasks call <code>getWriter</code>; reduce tasks call <code>getReader</code> for a range of map indices and partitions; and <code>shuffleBlockResolver</code> turns block ids into physical locations.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala#L38-L96">ShuffleManager.scala L38-L96 — the trait</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>SortShuffleManager — why one file per map task</summary>
+          <div class="details-body">
+            <p>Sort-based shuffle sorts incoming records by their target partition id and writes them to a <em>single</em> map output file, with reducers fetching contiguous regions. This keeps the number of files at O(map tasks) instead of O(map × reduce), which is what made shuffles scale to large clusters. If the data is too large to fit in memory, sorted runs spill to disk and are merged.</p>
+            <p>There are two write paths. The <strong>serialized</strong> path operates on serialized bytes (less GC, cache-efficient pointer sorting) and is used when there is no map-side combine, the serializer supports relocation (e.g. Kryo), and there are ≤ 16,777,216 partitions. Everything else uses the <strong>deserialized</strong> path.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala#L30-L73">SortShuffleManager.scala L30-L73 — design &amp; write paths</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala#L90-L176">SortShuffleManager.scala L90-L176 — registerShuffle, getReader, getWriter</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>The writer: ExternalSorter to a partitioned file</summary>
+          <div class="details-body">
+            <p><code>SortShuffleWriter.write</code> feeds all records into an <code>ExternalSorter</code> (which sorts and spills as needed), opens a map output writer, writes each partition's bytes in order, and produces a <code>MapStatus</code> describing the block manager that holds the file and the byte length of each partition. That <code>MapStatus</code> is what gets registered with the driver and later read by reducers.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala#L65-L89">SortShuffleWriter.scala L65-L89 — write</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala#L46-L63">IndexShuffleBlockResolver.scala L46-L63 — data + index layout</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>The reader: fetch, then optionally re-sort</summary>
+          <div class="details-body">
+            <p><code>BlockStoreShuffleReader.read</code> opens a <code>ShuffleBlockFetcherIterator</code> over the <code>(BlockManagerId, blocks)</code> list that the manager obtained from the tracker. It streams remote blocks (with limits on in-flight bytes), deserializes each into key/value pairs, applies a map-side combiner if present, and re-sorts on the reduce side only when a key ordering is required (e.g. <code>sortByKey</code>).</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala#L72-L112">BlockStoreShuffleReader.scala L72-L112 — read</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>IndexShuffleBlockResolver — reading just your slice</summary>
+          <div class="details-body">
+            <p>Each map task writes a <code>.data</code> file and a <code>.index</code> file of partition offsets. When a reducer requests partition <code>r</code>, <code>getBlockData</code> reads the start and end offsets from the index and returns a <code>FileSegmentManagedBuffer</code> pointing at exactly that region of the data file — no copy, no scan of other partitions. This is the mechanism that makes the single-file design efficient to read.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala#L616-L660">IndexShuffleBlockResolver.scala L616-L660 — getBlockData</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>MapOutputTracker — the location directory</summary>
+          <div class="details-body">
+            <p>The tracker answers the reduce side's central question: "for shuffle X and partition r, which executors hold the blocks and how big are they?" The <code>MapOutputTrackerMaster</code> on the driver records a <code>MapStatus</code> per map task; the <code>MapOutputTrackerWorker</code> on executors caches that information, fetching it over RPC on a miss. An <strong>epoch</strong> counter is incremented whenever outputs are lost, so executors know to discard stale cached locations after a failure.</p>
+            <pre><code>reduce task → MapOutputTrackerWorker.getMapSizesByExecutorId(shuffleId, ...)
+            → (cache miss) RPC to MapOutputTrackerMaster
+            → Seq[(BlockManagerId, Seq[(blockId, size, mapIndex)])]
+            → ShuffleBlockFetcherIterator</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala#L549-L623">MapOutputTracker.scala L549-L623 — base tracker &amp; the reduce-side API</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala#L1314-L1324">MapOutputTracker.scala L1314-L1324 — getMapSizesByExecutorId</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Why shuffles dominate cost</h2>
+        <p>A shuffle materializes intermediate data to disk and moves much of it across the network. It is also a hard synchronization barrier: the reduce stage cannot start until enough map output exists. That is why so much of Spark tuning — partition counts, partitioners, broadcast joins, adaptive query execution, and push-based shuffle — is ultimately about <em>avoiding</em> or <em>shrinking</em> shuffles. The number of reduce partitions is set by the partitioner (for RDDs) or <code>spark.sql.shuffle.partitions</code> (for SQL, default 200).</p>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Key takeaways</h2>
+          <ul>
+            <li>Map tasks write one sorted data file plus an index; reducers fetch contiguous slices.</li>
+            <li>The single-file design keeps file counts O(map) instead of O(map × reduce).</li>
+            <li>The <code>MapOutputTracker</code> directory plus its epoch make fetches correct under failure.</li>
+            <li>Shuffles are a barrier and the main target of performance tuning.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://spark.apache.org/docs/latest/rdd-programming-guide.html#shuffle-operations">Shuffle operations guide</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/sql-performance-tuning.html#adaptive-query-execution">Adaptive Query Execution</a></li>
+            <li><a href="https://issues.apache.org/jira/browse/SPARK-30602">SPARK-30602 — push-based shuffle (Magnet)</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>Code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/spark-data-flow/components/spark-sql-catalyst.html
+++ b/explainers/spark-data-flow/components/spark-sql-catalyst.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Spark SQL &amp; Catalyst — Spark Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>Apache Spark Data Flow</strong>
+        <span>apache/spark @ <code>583e5bb</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="driver-and-context.html">Driver &amp; SparkContext</a>
+        <a href="rdd-and-lineage.html">RDD &amp; Lineage</a>
+        <a href="scheduler.html">DAG &amp; Task Scheduling</a>
+        <a href="execution-and-memory.html">Executor, Storage &amp; Memory</a>
+        <a href="shuffle.html">Shuffle</a>
+        <a href="spark-sql-catalyst.html" aria-current="page">Spark SQL &amp; Catalyst</a>
+        <a href="structured-streaming.html">Structured Streaming</a>
+        <a href="cluster-deploy.html">Cluster &amp; Deploy</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Spark SQL: from a query to an RDD of rows</h1>
+          <p class="lead">DataFrames and SQL do not bypass the engine you have already seen — they compile down to it. The Catalyst optimizer rewrites a tree of relational operators through well-defined phases, Tungsten generates tight Java code, and the result is an <code>RDD[InternalRow]</code> scheduled exactly like any other job.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>The query pipeline</h2>
+        <pre><code>SQL text / DataFrame ops
+   │  parse
+   ▼
+Unresolved LogicalPlan
+   │  Analyzer        (resolve tables, columns, functions, types)
+   ▼
+Analyzed LogicalPlan
+   │  Optimizer       (predicate pushdown, column pruning, constant folding, ...)
+   ▼
+Optimized LogicalPlan
+   │  SparkPlanner    (strategies map logical → physical operators)
+   ▼
+SparkPlan (physical)
+   │  preparations    (EnsureRequirements adds shuffles, CollapseCodegenStages, AQE)
+   ▼
+executedPlan
+   │  execute()
+   ▼
+RDD[InternalRow]  ──► the scheduler, stages, tasks (same as everything else)</code></pre>
+        <p>Each arrow is a lazy phase in <code>QueryExecution</code>; an action on a <code>Dataset</code> forces <code>executedPlan</code>, which pulls all the earlier phases.</p>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>SparkSession and Dataset — lazy by construction</summary>
+          <div class="details-body">
+            <p><code>SparkSession.sql(...)</code> parses text into an unresolved <code>LogicalPlan</code> and wraps it in a <code>Dataset</code> via <code>Dataset.ofRows</code>. A <code>Dataset</code> is just a <code>QueryExecution</code> plus an <code>Encoder</code>; every DataFrame transformation produces a new logical plan. Nothing runs until an action like <code>collect</code> calls <code>withAction</code>, which forces the executed plan and collects rows.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala#L528-L559">SparkSession.scala L528-L559 — sql()</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/classic/Dataset.scala#L110-L138">Dataset.scala L110-L138 — ofRows</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>QueryExecution — the phase orchestrator</summary>
+          <div class="details-body">
+            <p>Each phase is a <code>lazy val</code>: <code>analyzed</code>, <code>optimizedPlan</code>, <code>sparkPlan</code>, <code>executedPlan</code>, and finally <code>toRdd</code>. Accessing one forces the previous, so the whole pipeline runs on demand and the planning time of each phase is tracked separately.</p>
+            <pre><code>analyzed       = analyzer.executeAndCheck(logical)
+optimizedPlan  = optimizer.executeAndTrack(withCachedData)
+sparkPlan      = createSparkPlan(planner, optimizedPlan)
+executedPlan   = prepareForExecution(preparations, sparkPlan)
+toRdd          = new SQLExecutionRDD(executedPlan.execute(), conf)</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala#L313-L394">QueryExecution.scala L313-L394 — optimized, spark, executed, toRdd</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>TreeNode and Rule — Catalyst's whole foundation</summary>
+          <div class="details-body">
+            <p>Every plan, expression, and data type in Catalyst is a <code>TreeNode</code>: an immutable node with children. All transformations are expressed as <code>transformDown</code>/<code>transformUp</code> traversals that return a rewritten tree. A <code>Rule</code> is a single rewrite step (<code>apply(tree): tree</code>), and the <code>RuleExecutor</code> runs batches of rules until they reach a fixed point. This tiny abstraction is why adding an optimization is just writing a new rule.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala#L70-L75">TreeNode.scala L70-L75 — base node</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/Rule.scala#L24-L35">Rule.scala L24-L35 — Rule</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Analyzer — resolving the unresolved</summary>
+          <div class="details-body">
+            <p>The parser produces a plan full of <code>UnresolvedRelation</code> and <code>UnresolvedAttribute</code> placeholders. The <code>Analyzer</code> (a <code>RuleExecutor</code>) consults the catalog to bind table and column references, resolve functions, add casts for type coercion, and validate the result. Its output is a fully typed, analyzed logical plan.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala#L300-L309">Analyzer.scala L300-L309 — class</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala#L506-L609">Analyzer.scala L506-L609 — resolution batches</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Optimizer — cost-agnostic rewrites</summary>
+          <div class="details-body">
+            <p>The <code>Optimizer</code> applies rule batches that make the plan cheaper without changing its meaning: predicate pushdown, column pruning, constant folding, filter combination, boolean simplification, join reordering, and subquery rewriting. These are heuristic (rule-based) rewrites; statistics-driven choices like join strategy happen during physical planning and Adaptive Query Execution.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala#L100-L291">Optimizer.scala L100-L291 — default rule batches</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>SparkPlanner — logical to physical</summary>
+          <div class="details-body">
+            <p>Physical planning applies a list of <strong>strategies</strong> that pattern-match logical operators and emit physical <code>SparkPlan</code> operators (the <code>*Exec</code> classes). <code>JoinSelection</code> decides between broadcast, sort-merge, and shuffle-hash joins; <code>FileSourceStrategy</code> turns a scan into a file read with pushed-down filters; <code>BasicOperators</code> maps the simple cases. The planner takes the first complete candidate.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanner.scala#L31-L57">SparkPlanner.scala L31-L57 — the strategy list</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala#L906-L949">SparkStrategies.scala L906-L949 — BasicOperators</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>SparkPlan — where SQL meets RDDs</summary>
+          <div class="details-body">
+            <p>A <code>SparkPlan</code> is a physical operator. Its <code>doExecute()</code> returns an <code>RDD[InternalRow]</code> — the bridge back to the RDD engine. <code>InternalRow</code> (and its binary form <code>UnsafeRow</code>) is Tungsten's compact, off-heap-friendly row layout that flows through these RDDs, avoiding Java object overhead.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala#L197-L202">SparkPlan.scala L197-L202 — execute</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala#L338-L343">SparkPlan.scala L338-L343 — doExecute returns RDD[InternalRow]</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Tungsten: whole-stage code generation</summary>
+          <div class="details-body">
+            <p>A naive operator tree calls <code>next()</code> through many virtual method calls per row (the "volcano" model). <code>CollapseCodegenStages</code>, a preparation rule, fuses a chain of codegen-capable operators (scan → filter → project) into a <em>single generated Java class</em> with one tight loop. <code>WholeStageCodegenExec.doExecute()</code> compiles that source at runtime and runs it, falling back to normal execution if compilation fails. This is the largest single performance feature in modern Spark SQL.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala#L673-L749">WholeStageCodegenExec.scala L673-L749 — doCodeGen &amp; doExecute</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala#L914-L994">WholeStageCodegenExec.scala L914-L994 — CollapseCodegenStages</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>The payoff: one engine, two front ends</h2>
+        <p>Because Catalyst lowers everything to a <code>SparkPlan</code> and then to an <code>RDD[InternalRow]</code>, a SQL query and a hand-written RDD job share the same scheduler, shuffle, memory, and executor machinery described on the other pages. The difference is that the SQL front end knows the <em>schema</em> and the <em>relational semantics</em>, so it can optimize aggressively (pruning columns, pushing filters into scans, picking join algorithms) before a single task is scheduled.</p>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Key takeaways</h2>
+          <ul>
+            <li>SQL/DataFrames compile through analyze → optimize → plan → prepare → RDD.</li>
+            <li>Everything is a <code>TreeNode</code>; every optimization is a <code>Rule</code> run to a fixed point.</li>
+            <li><code>SparkPlan.doExecute</code> returns an <code>RDD[InternalRow]</code> — the link to the core engine.</li>
+            <li>Whole-stage codegen fuses operators into one compiled loop over <code>UnsafeRow</code>s.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://dl.acm.org/doi/10.1145/2723372.2742797">Spark SQL paper (SIGMOD 2015)</a></li>
+            <li><a href="https://www.databricks.com/blog/2015/04/13/deep-dive-into-spark-sqls-catalyst-optimizer.html">Deep dive into Catalyst</a></li>
+            <li><a href="https://www.databricks.com/blog/2016/05/23/apache-spark-as-a-compiler-joining-a-billion-rows-per-second-on-a-laptop.html">Whole-stage codegen (Tungsten)</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/sql-performance-tuning.html">SQL performance tuning</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>Code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/spark-data-flow/components/structured-streaming.html
+++ b/explainers/spark-data-flow/components/structured-streaming.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Structured Streaming — Spark Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>Apache Spark Data Flow</strong>
+        <span>apache/spark @ <code>583e5bb</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="driver-and-context.html">Driver &amp; SparkContext</a>
+        <a href="rdd-and-lineage.html">RDD &amp; Lineage</a>
+        <a href="scheduler.html">DAG &amp; Task Scheduling</a>
+        <a href="execution-and-memory.html">Executor, Storage &amp; Memory</a>
+        <a href="shuffle.html">Shuffle</a>
+        <a href="spark-sql-catalyst.html">Spark SQL &amp; Catalyst</a>
+        <a href="structured-streaming.html" aria-current="page">Structured Streaming</a>
+        <a href="cluster-deploy.html">Cluster &amp; Deploy</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Structured Streaming: a stream as an unbounded table</h1>
+          <p class="lead">Structured Streaming reuses the entire SQL engine. A streaming query is executed as a series of small batches: each trigger reads new offsets, runs an ordinary query over just the new data, and commits the result transactionally. A write-ahead log and a commit log make the whole thing fault-tolerant and exactly-once for supported sinks.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>The micro-batch loop</h2>
+        <pre><code>df.writeStream...start()
+   │
+   ▼
+StreamingQueryManager.createQuery → MicroBatchExecution → StreamExecution.start()
+   │
+   ▼  dedicated query-execution thread runs runActivatedStream()
+   │
+   ╭───────────────────────── per trigger ─────────────────────────╮
+   │ 1. poll each Source for its latest offset                      │
+   │ 2. write those offsets to the OFFSET LOG (write-ahead)         │
+   │ 3. build a normal QueryExecution over [lastOffset, newOffset)  │
+   │ 4. run the batch → write results to the Sink                   │
+   │ 5. write the batch id to the COMMIT LOG                        │
+   │ 6. tell sources they may discard committed data               │
+   ╰────────────────────────────────────────────────────────────────╯
+   (repeat until stopped)</code></pre>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>From writeStream to a running query</summary>
+          <div class="details-body">
+            <p>Calling <code>start()</code> on a <code>DataStreamWriter</code> resolves the checkpoint location and trigger, then asks the <code>StreamingQueryManager</code> to create the query. The manager picks the engine: a <code>ContinuousExecution</code> for a continuous trigger with a v2 sink, otherwise a <code>MicroBatchExecution</code> (the default). It then starts the query's dedicated thread.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataStreamWriter.scala#L304-L333">DataStreamWriter.scala L304-L333 — startQuery</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/classic/StreamingQueryManager.scala#L177-L257">StreamingQueryManager.scala L177-L257 — createQuery picks the engine</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>StreamExecution — the engine base</summary>
+          <div class="details-body">
+            <p><code>StreamExecution</code> is the abstract base for streaming query execution. It owns the checkpoint metadata, the offset and commit logs, and the lifecycle state. Crucially it runs the query on its own <code>UninterruptibleThread</code> (<code>queryExecutionThread</code>) to avoid interrupt-related hangs in source clients, repeatedly attempting batches until the query is stopped.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala#L74-L84">StreamExecution.scala L74-L84 — class</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/StreamExecution.scala#L282-L358">StreamExecution.scala L282-L358 — runStream activation loop</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>MicroBatchExecution — one trigger at a time</summary>
+          <div class="details-body">
+            <p><code>runActivatedStream</code> drives a <code>TriggerExecutor</code> that calls <code>executeOneBatch</code> on each tick. A batch constructs the next offsets, runs the batch if there is new data or pending state cleanup, then advances the batch id. The default <code>ProcessingTimeExecutor</code> simply loops, running a batch and sleeping until the next interval.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala#L592-L687">MicroBatchExecution.scala L592-L687 — runActivatedStream &amp; executeOneBatch</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>runBatch — a normal query over new data</summary>
+          <div class="details-body">
+            <p>The heart of the design: <code>runBatch</code> asks each source for the records between the committed offset and the new offset, rewires those into the logical plan, builds an <code>IncrementalExecution</code> (the same Catalyst pipeline, extended with stateful-operator rules), and writes the output to the sink. The streaming "magic" is mostly bookkeeping around an otherwise ordinary batch query.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala#L1017-L1250">MicroBatchExecution.scala L1017-L1250 — runBatch</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Offsets, the WAL, and exactly-once</summary>
+          <div class="details-body">
+            <p>Fault tolerance comes from two append-only logs in the checkpoint directory. The <strong>offset log</strong> records, <em>before</em> a batch runs, exactly which input range that batch will process (a write-ahead log). The <strong>commit log</strong> records, <em>after</em> a batch succeeds, that the batch is durably complete. On restart the engine compares the two: if the last batch was written to the offset log but not the commit log, it re-runs it. Combined with idempotent sinks, this yields end-to-end exactly-once processing.</p>
+            <pre><code>offsets/   ← OffsetSeqLog : "batch N will read up to these offsets"   (BEFORE)
+commits/   ← CommitLog    : "batch N completed"                      (AFTER)
+state/     ← versioned state store for stateful operators
+metadata/  ← stream id</code></pre>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/MicroBatchExecution.scala#L1257-L1275">MicroBatchExecution.scala L1257-L1275 — markMicroBatchStart (offset WAL)</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/checkpointing/HDFSMetadataLog.scala#L205-L246">HDFSMetadataLog.scala L205-L246 — atomic write (temp-then-rename)</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Sources and sinks</summary>
+          <div class="details-body">
+            <p>A <code>Source</code> exposes <code>getOffset</code> (the latest available position), <code>getBatch(start, end)</code> (the data in a range), and <code>commit(end)</code> (permission to discard). A <code>Sink</code> exposes an idempotent <code>addBatch(batchId, data)</code>. These small contracts (and their v2 equivalents) are what let connectors like Kafka, files, and Delta plug into the same execution loop with consistent recovery semantics.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Source.scala#L32-L67">Source.scala L32-L67</a></p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/Sink.scala#L34-L47">Sink.scala L34-L47</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Continuous processing (the other engine)</h2>
+        <p>For the lowest latency, a <code>ContinuousExecution</code> runs long-lived tasks that process records as they arrive, checkpointing progress by <em>epoch</em> rather than by discrete batches. It is a separate code path selected only for a continuous trigger with a compatible v2 sink; the micro-batch engine remains the default and the most widely used.</p>
+        <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala#L49-L57">ContinuousExecution.scala L49-L57</a></p>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Key takeaways</h2>
+          <ul>
+            <li>A streaming query is a loop of ordinary batch queries over new input ranges.</li>
+            <li>The offset log is written before a batch; the commit log after — this ordering enables replay.</li>
+            <li>Idempotent sinks plus the two logs give end-to-end exactly-once semantics.</li>
+            <li>Continuous mode trades the batch model for epoch-based low-latency processing.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://dl.acm.org/doi/10.1145/3242153.3242155">Structured Streaming paper (SIGMOD 2018)</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html">Structured Streaming guide</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#fault-tolerance-semantics">Fault-tolerance semantics</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>Code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/spark-data-flow/index.html
+++ b/explainers/spark-data-flow/index.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Apache Spark Data Flow — Overview</title>
+  <link rel="stylesheet" href="assets/styles.css">
+  <script src="assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>Apache Spark Data Flow</strong>
+        <span>apache/spark @ <code>583e5bb</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="index.html" aria-current="page">Overview</a>
+        <a href="components/driver-and-context.html">Driver &amp; SparkContext</a>
+        <a href="components/rdd-and-lineage.html">RDD &amp; Lineage</a>
+        <a href="components/scheduler.html">DAG &amp; Task Scheduling</a>
+        <a href="components/execution-and-memory.html">Executor, Storage &amp; Memory</a>
+        <a href="components/shuffle.html">Shuffle</a>
+        <a href="components/spark-sql-catalyst.html">Spark SQL &amp; Catalyst</a>
+        <a href="components/structured-streaming.html">Structured Streaming</a>
+        <a href="components/cluster-deploy.html">Cluster &amp; Deploy</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>From your program to distributed computation</h1>
+          <p class="lead">A guided tour of how Apache Spark turns a user program into work that runs across a cluster. It follows one piece of data from the driver, through the scheduler, onto executors, across a shuffle, and back. Code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>The mental model in one paragraph</h2>
+        <p>A Spark application has one <strong>driver</strong> process and many <strong>executor</strong> processes. The driver runs your code and holds a <code>SparkContext</code> (or a <code>SparkSession</code> for SQL/DataFrames). When you transform data, Spark does not compute anything; it records a lazy <strong>lineage graph</strong> of RDDs. When you call an <strong>action</strong>, the driver hands the lineage to the <code>DAGScheduler</code>, which cuts it into <strong>stages</strong> at shuffle boundaries and submits each stage as a set of <strong>tasks</strong>. The <code>TaskScheduler</code> sends tasks to executors over a <code>SchedulerBackend</code>. Each executor runs tasks, reads and writes blocks through its <code>BlockManager</code>, exchanges data through the <strong>shuffle</strong> system, and reports results back to the driver.</p>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>The two planes: control and data</h2>
+        <pre><code>             CONTROL PLANE                                  DATA PLANE
+        ┌───────────────────────────┐               ┌───────────────────────────┐
+        │           DRIVER           │               │         EXECUTOR(S)        │
+        │                            │   tasks       │                            │
+        │  SparkContext / Session    │ ───────────►  │  CoarseGrainedExecutor     │
+        │    DAGScheduler            │               │    Executor + TaskRunner   │
+        │    TaskSchedulerImpl       │ ◄───────────  │    BlockManager            │
+        │    SchedulerBackend        │   results     │    ShuffleManager          │
+        │    MapOutputTrackerMaster  │   heartbeats  │    MemoryManager           │
+        └─────────────┬──────────────┘               └─────────────┬──────────────┘
+                      │ asks for executors                         │ shuffle files
+                      ▼                                            ▼
+        ┌───────────────────────────┐               ┌───────────────────────────┐
+        │   CLUSTER MANAGER          │               │   LOCAL DISK / REMOTE      │
+        │  Standalone / YARN / K8s   │               │   BLOCK TRANSFER SERVICE   │
+        └───────────────────────────┘               └───────────────────────────┘</code></pre>
+        <p>The driver is the <strong>control plane</strong>: it decides what to run and where. Executors are the <strong>data plane</strong>: they hold cached partitions, run task code, and move shuffle data between each other. A cluster manager only places processes; it does not participate in scheduling individual tasks.</p>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>One job, end to end</h2>
+        <p>Click a step to highlight the block that explains it. Every step is also detailed on a dedicated component page.</p>
+        <div class="flow">
+          <button class="flow-step" data-flow-step="boot">
+            <span class="step-label">1. Driver boot</span>
+            <span><code>new SparkContext(conf)</code> builds <code>SparkEnv</code> (serializer, block manager, map output tracker) and the scheduler stack.</span>
+          </button>
+          <button class="flow-step" data-flow-step="lineage">
+            <span class="step-label">2. Build lineage (lazy)</span>
+            <span>Transformations such as <code>map</code> and <code>filter</code> return new RDDs linked by <code>Dependency</code> edges. Nothing executes yet.</span>
+          </button>
+          <button class="flow-step" data-flow-step="action">
+            <span class="step-label">3. Action triggers a job</span>
+            <span><code>collect</code>/<code>count</code> call <code>SparkContext.runJob</code>, the single entry point for all actions.</span>
+          </button>
+          <button class="flow-step" data-flow-step="stages">
+            <span class="step-label">4. Plan stages</span>
+            <span>The <code>DAGScheduler</code> walks the lineage and cuts it into a <code>ResultStage</code> plus ancestor <code>ShuffleMapStage</code>s at shuffle boundaries.</span>
+          </button>
+          <button class="flow-step" data-flow-step="tasks">
+            <span class="step-label">5. Submit tasks</span>
+            <span>Each ready stage becomes a <code>TaskSet</code>; the <code>TaskSchedulerImpl</code> assigns tasks to executors using locality.</span>
+          </button>
+          <button class="flow-step" data-flow-step="run">
+            <span class="step-label">6. Run on executors</span>
+            <span>A <code>TaskRunner</code> deserializes the task and calls <code>RDD.iterator</code>, which computes or reads a cached/checkpointed partition.</span>
+          </button>
+          <button class="flow-step" data-flow-step="shuffle">
+            <span class="step-label">7. Shuffle exchange</span>
+            <span>Map tasks write partitioned files; the <code>MapOutputTracker</code> records locations; reduce tasks fetch their slices.</span>
+          </button>
+          <button class="flow-step" data-flow-step="result">
+            <span class="step-label">8. Return results</span>
+            <span>Result tasks send values back to the driver, which assembles the action's return value.</span>
+          </button>
+        </div>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable" data-flow-target="boot">
+          <summary>1. The driver builds its runtime first</summary>
+          <div class="details-body">
+            <p>Constructing a <code>SparkContext</code> is the moment a Spark application comes alive. It clones the <code>SparkConf</code>, creates a <code>SparkEnv</code> (the container of shared services: serializer, <code>BlockManager</code>, <code>MapOutputTracker</code>, shuffle and memory managers), then builds the scheduler trio: a <code>SchedulerBackend</code>, a <code>TaskSchedulerImpl</code>, and a <code>DAGScheduler</code>.</p>
+            <p>The factory <code>createTaskScheduler</code> matches on the master URL (<code>local[*]</code>, <code>spark://</code>, YARN, Kubernetes) and picks the right backend, which is how the same code runs on a laptop or a thousand-node cluster.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkContext.scala#L599-L603">SparkContext.scala L599-L603 — scheduler creation</a></p>
+            <p>Full detail: <a href="components/driver-and-context.html">Driver &amp; SparkContext</a>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="lineage">
+          <summary>2. Transformations only describe the computation</summary>
+          <div class="details-body">
+            <p>An <code>RDD</code> is an immutable, partitioned collection defined by five properties: its partitions, a <code>compute</code> function, a list of dependencies, an optional partitioner, and optional preferred locations. A transformation like <code>map</code> simply wraps the parent in a new <code>MapPartitionsRDD</code> — it builds a node in a graph rather than moving data.</p>
+            <p>The <strong>type</strong> of dependency decides everything downstream: a <code>NarrowDependency</code> (map, filter) can be pipelined; a <code>ShuffleDependency</code> forces a data exchange and therefore a stage boundary.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L69-L83">RDD.scala L69-L83 — the five properties</a></p>
+            <p>Full detail: <a href="components/rdd-and-lineage.html">RDD &amp; Lineage</a>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="action">
+          <summary>3. Actions are the only thing that launches work</summary>
+          <div class="details-body">
+            <p>Transformations are lazy; <strong>actions</strong> are eager. <code>collect</code>, <code>count</code>, <code>reduce</code>, and <code>save</code> all funnel through <code>SparkContext.runJob</code>, documented in the source as "the main entry point for all actions in Spark." It cleans the user closure, logs the call site, and delegates to <code>DAGScheduler.runJob</code>.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkContext.scala#L2471-L2499">SparkContext.scala L2471-L2499 — runJob</a></p>
+            <p>Full detail: <a href="components/rdd-and-lineage.html">RDD &amp; Lineage</a>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="stages">
+          <summary>4. The DAGScheduler turns a graph into stages</summary>
+          <div class="details-body">
+            <p>The <code>DAGScheduler</code> is the high-level, stage-oriented scheduler. It breaks the RDD graph at shuffle boundaries: narrow dependencies are pipelined into one stage, while each shuffle dependency creates a barrier between a <code>ShuffleMapStage</code> (which writes map output) and the stage that reads it. Every job ends in exactly one <code>ResultStage</code>.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L58-L72">DAGScheduler.scala L58-L72 — stage boundaries</a></p>
+            <p>Full detail: <a href="components/scheduler.html">DAG &amp; Task Scheduling</a>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="tasks">
+          <summary>5. Stages become TaskSets placed by locality</summary>
+          <div class="details-body">
+            <p>When a stage's parents are ready, <code>submitMissingTasks</code> builds one task per missing partition and submits them as a <code>TaskSet</code>. The <code>TaskSchedulerImpl</code> hands each <code>TaskSet</code> to a <code>TaskSetManager</code>, then fills executor "offers" by walking locality levels from <code>PROCESS_LOCAL</code> to <code>ANY</code>, preferring executors that already hold the data.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala#L512-L520">TaskSchedulerImpl.scala L512-L520 — resourceOffers</a></p>
+            <p>Full detail: <a href="components/scheduler.html">DAG &amp; Task Scheduling</a>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="run">
+          <summary>6. Executors deserialize and run each task</summary>
+          <div class="details-body">
+            <p>The driver sends a <code>LaunchTask</code> message; the executor's backend decodes the <code>TaskDescription</code> and calls <code>Executor.launchTask</code>, which submits a <code>TaskRunner</code> to a thread pool. The runner deserializes the task, fetches dependencies, and calls <code>task.run</code>. Inside, the task calls <code>RDD.iterator</code>, which returns cached data, reads a checkpoint, or calls <code>compute</code> to materialize the partition.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L334-L340">RDD.scala L334-L340 — iterator</a></p>
+            <p>Full detail: <a href="components/execution-and-memory.html">Executor, Storage &amp; Memory</a>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="shuffle">
+          <summary>7. The shuffle moves data between stages</summary>
+          <div class="details-body">
+            <p>A <code>ShuffleMapTask</code> sorts its records by target partition and writes a single data file plus an index file, then reports a <code>MapStatus</code> to the driver's <code>MapOutputTrackerMaster</code>. A downstream reduce task asks the tracker where its blocks live and fetches contiguous byte ranges from each map output through the block transfer service.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala#L30-L45">SortShuffleManager.scala L30-L45 — sort-based shuffle</a></p>
+            <p>Full detail: <a href="components/shuffle.html">Shuffle</a>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="result">
+          <summary>8. Results flow back and the job completes</summary>
+          <div class="details-body">
+            <p>A <code>ResultTask</code> runs the action's function over its partition and sends the value to the driver (inline for small results, via the block manager for large ones). The <code>DAGScheduler</code> records each completion; when the <code>ResultStage</code> has all partitions, the job's <code>JobWaiter</code> wakes up and <code>runJob</code> returns.</p>
+            <p class="coderef"><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/ResultTask.scala#L55-L72">ResultTask.scala L55-L72 — ResultTask</a></p>
+            <p>Full detail: <a href="components/scheduler.html">DAG &amp; Task Scheduling</a>.</p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section searchable">
+        <h2>The core objects you will keep meeting</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Object</th>
+                <th>Role in the data flow</th>
+                <th>Defined in</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>SparkContext</code></td>
+                <td>Driver-side entry point; creates the runtime and is the gateway to every action.</td>
+                <td><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkContext.scala#L86">SparkContext.scala</a></td>
+              </tr>
+              <tr>
+                <td><code>SparkEnv</code></td>
+                <td>Container of shared runtime services, reachable on any node via <code>SparkEnv.get</code>.</td>
+                <td><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/SparkEnv.scala#L64-L76">SparkEnv.scala</a></td>
+              </tr>
+              <tr>
+                <td><code>RDD[T]</code></td>
+                <td>The lazy, partitioned collection; the unit of lineage.</td>
+                <td><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L84-L87">RDD.scala</a></td>
+              </tr>
+              <tr>
+                <td><code>Dependency</code></td>
+                <td>An edge between RDDs; narrow vs. shuffle decides stage boundaries.</td>
+                <td><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/Dependency.scala#L41-L43">Dependency.scala</a></td>
+              </tr>
+              <tr>
+                <td><code>Stage</code></td>
+                <td>A set of parallel tasks over one RDD, bounded by shuffles.</td>
+                <td><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala#L56-L64">Stage.scala</a></td>
+              </tr>
+              <tr>
+                <td><code>Task</code></td>
+                <td>The serializable unit of work shipped to an executor.</td>
+                <td><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/scheduler/Task.scala#L61-L74">Task.scala</a></td>
+              </tr>
+              <tr>
+                <td><code>BlockManager</code></td>
+                <td>Per-node store for cached partitions, broadcast, and shuffle blocks.</td>
+                <td><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala#L182-L194">BlockManager.scala</a></td>
+              </tr>
+              <tr>
+                <td><code>MapOutputTracker</code></td>
+                <td>Driver registry of where each shuffle map output lives.</td>
+                <td><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala#L549-L556">MapOutputTracker.scala</a></td>
+              </tr>
+              <tr>
+                <td><code>SparkSession</code></td>
+                <td>Entry point for SQL and DataFrames; wraps a <code>SparkContext</code>.</td>
+                <td><a href="https://github.com/apache/spark/blob/583e5bb0010b52a0201a092985b09b0b2c264a6a/sql/core/src/main/scala/org/apache/spark/sql/classic/SparkSession.scala#L92-L99">SparkSession.scala</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Component pages</h2>
+          <ul>
+            <li><a href="components/driver-and-context.html">Driver &amp; SparkContext</a>: boot sequence, <code>SparkConf</code>, <code>SparkEnv</code>, the scheduler trio.</li>
+            <li><a href="components/rdd-and-lineage.html">RDD &amp; Lineage</a>: the five properties, transformations vs. actions, dependencies, partitioning, caching.</li>
+            <li><a href="components/scheduler.html">DAG &amp; Task Scheduling</a>: stages, tasks, <code>TaskSetManager</code>, locality, retries, fault recovery.</li>
+            <li><a href="components/execution-and-memory.html">Executor, Storage &amp; Memory</a>: <code>TaskRunner</code>, <code>BlockManager</code>, unified memory.</li>
+            <li><a href="components/shuffle.html">Shuffle</a>: sort-based shuffle, writers/readers, the map output tracker.</li>
+            <li><a href="components/spark-sql-catalyst.html">Spark SQL &amp; Catalyst</a>: logical plans, the optimizer, physical planning, Tungsten codegen.</li>
+            <li><a href="components/structured-streaming.html">Structured Streaming</a>: the micro-batch loop, offsets, checkpoints, exactly-once.</li>
+            <li><a href="components/cluster-deploy.html">Cluster &amp; Deploy</a>: <code>spark-submit</code>, deploy modes, Standalone master/worker.</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://people.csail.mit.edu/matei/papers/2012/nsdi_spark.pdf">RDD paper (NSDI 2012)</a> — the original abstraction.</li>
+            <li><a href="https://www.usenix.org/system/files/conference/nsdi12/nsdi12-final138.pdf">Resilient Distributed Datasets (full)</a></li>
+            <li><a href="https://dl.acm.org/doi/10.1145/2723372.2742797">Spark SQL paper (SIGMOD 2015)</a> — Catalyst and DataFrames.</li>
+            <li><a href="https://dl.acm.org/doi/10.1145/3242153.3242155">Structured Streaming paper (SIGMOD 2018)</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/cluster-overview.html">Spark cluster mode overview</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/rdd-programming-guide.html">RDD programming guide</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/sql-programming-guide.html">Spark SQL guide</a></li>
+            <li><a href="https://spark.apache.org/docs/latest/tuning.html">Memory tuning guide</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>An educational walkthrough of <a href="https://github.com/apache/spark">apache/spark</a>. All code references are GitHub permalinks pinned to commit <code>583e5bb0010b52a0201a092985b09b0b2c264a6a</code>. Spark is licensed under Apache-2.0.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a mobile-friendly, interactive explainer for **Apache Spark** under `explainers/spark-data-flow/`, following the existing `claude-code-data-flow` folder convention (overview `index.html` + per-component pages + shared `assets/`).

It traces one piece of data from the driver, through the scheduler, onto executors, across a shuffle, and back — then drills into each subsystem on its own page. All code references are GitHub permalinks pinned to `apache/spark@583e5bb0010b52a0201a092985b09b0b2c264a6a` (a fresh clone was used to ground every reference).

## Pages

- **Overview** — the control/data plane model and an 8-step end-to-end job walkthrough.
- **Driver & SparkContext** — boot sequence, `SparkConf`, `SparkEnv`, the scheduler trio, `runJob`.
- **RDD & Lineage** — the five properties, transformations vs. actions, narrow vs. shuffle dependencies, partitioning, caching.
- **DAG & Task Scheduling** — `DAGScheduler` stages, `ResultStage`/`ShuffleMapStage`, tasks, `TaskSchedulerImpl`, `TaskSetManager`, locality, fault recovery.
- **Executor, Storage & Memory** — `TaskRunner`, `BlockManager`, the unified memory model, memory/disk tiers.
- **Shuffle** — sort-based shuffle, writers/readers, `IndexShuffleBlockResolver`, `MapOutputTracker`.
- **Spark SQL & Catalyst** — logical plans, `QueryExecution` phases, analyzer/optimizer, physical planning, Tungsten whole-stage codegen.
- **Structured Streaming** — the micro-batch loop, offsets, the WAL/commit-log, exactly-once.
- **Cluster & Deploy** — `spark-submit`, deploy modes, Standalone master/worker.

## Design / constraints

- Blocks use `<details open>` so everything is **expanded by default**; code blocks use `white-space: pre`.
- Reuses the established neutral, flat design language: **no gradients, glow, or thin colored borders**, a limited font-size scale, consistent spacing tokens, responsive single-column layout on small screens.
- Each page has expand/collapse-all and a client-side block filter.
- Every page links to **external references** (papers + official docs) for core ideas.

## Verification

- 109 permalinks validated against the clone: all file paths exist and line ranges are in-bounds; a sample was spot-checked to confirm they point at the described symbols.
- 0 broken internal links; confirmed no forbidden CSS (`gradient`, `box-shadow`, `text-shadow`, `blur`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6785081-5d7f-482a-a4de-1abbe6e45e7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6785081-5d7f-482a-a4de-1abbe6e45e7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

