### PR TITLE
Add raylib data flow interactive HTML explainers

### DIFF
--- a/explainers/raylib-data-flow/index.html
+++ b/explainers/raylib-data-flow/index.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>raylib Data Flow — Overview</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<nav class="site-nav">
+  <a class="brand" href="index.html">raylib Data Flow</a>
+  <a href="index.html" class="active">Overview</a>
+  <a href="rcore.html">rcore</a>
+  <a href="rlgl.html">rlgl</a>
+  <a href="rshapes.html">rshapes</a>
+  <a href="rtextures.html">rtextures</a>
+  <a href="rtext.html">rtext</a>
+  <a href="rmodels.html">rmodels</a>
+  <a href="raudio.html">raudio</a>
+</nav>
+
+<main>
+  <h1 class="page-title">raylib Architecture Overview</h1>
+  <p class="page-subtitle">How a C game loop flows from your <code>Draw*</code> calls through batched 2D rendering, shader-based 3D, and miniaudio playback — traced through the actual source modules.</p>
+  <p class="meta">Source snapshot: <a href="https://github.com/raysan5/raylib/tree/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8">raysan5/raylib @ 22509ab</a></p>
+
+  <details open>
+    <summary>What raylib Is</summary>
+    <div class="details-body">
+      <p><a href="https://www.raylib.com/">raylib</a> is a plain-C library for games and graphical apps. It wraps platform windowing (GLFW/SDL/RGFW), an OpenGL abstraction layer (<code>rlgl</code>), and optional modules for shapes, textures, text, 3D models, and audio — all behind a single header, <code>raylib.h</code>.</p>
+      <p>The canonical loop from the README:</p>
+      <pre><code>#include "raylib.h"
+
+int main(void)
+{
+    InitWindow(800, 450, "raylib example - basic window");
+
+    while (!WindowShouldClose())
+    {
+        BeginDrawing();
+            ClearBackground(RAYWHITE);
+            DrawText("Congrats! You created your first window!", 190, 200, 20, LIGHTGRAY);
+        EndDrawing();
+    }
+
+    CloseWindow();
+    return 0;
+}</code></pre>
+      <p>Every frame, user code sits between <code>BeginDrawing()</code> and <code>EndDrawing()</code>. Inside that window, draw calls accumulate GPU vertex data; at <code>EndDrawing()</code> the batch flushes, the back buffer swaps, and input is polled.</p>
+      <p class="code-label">Entry points in rcore</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L585-L720">InitWindow</a>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L858-L904">BeginDrawing / EndDrawing</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Module Map</summary>
+    <div class="details-body">
+      <p>raylib compiles as one library but splits responsibilities across source files. <code>rcore.c</code> and <code>rlgl.h</code> are mandatory; other modules are toggled via <code>config.h</code>.</p>
+      <div class="card-grid">
+        <a class="component-card" href="rcore.html">
+          <h3>rcore</h3>
+          <div class="file">src/rcore.c + src/platforms/*</div>
+          <p>Window, input, timing, frame loop, 2D/3D mode switching, render targets.</p>
+        </a>
+        <a class="component-card" href="rlgl.html">
+          <h3>rlgl</h3>
+          <div class="file">src/rlgl.h</div>
+          <p>OpenGL 1.1 / 3.3 / ES2 abstraction, render batching, shaders, GPU state.</p>
+        </a>
+        <a class="component-card" href="rshapes.html">
+          <h3>rshapes</h3>
+          <div class="file">src/rshapes.c</div>
+          <p>2D primitives — lines, circles, rectangles — via immediate-mode vertices.</p>
+        </a>
+        <a class="component-card" href="rtextures.html">
+          <h3>rtextures</h3>
+          <div class="file">src/rtextures.c</div>
+          <p>Image loading, GPU textures, render textures (FBOs), texture drawing.</p>
+        </a>
+        <a class="component-card" href="rtext.html">
+          <h3>rtext</h3>
+          <div class="file">src/rtext.c</div>
+          <p>Font loading (TTF, etc.), glyph atlas, text rendering as textured quads.</p>
+        </a>
+        <a class="component-card" href="rmodels.html">
+          <h3>rmodels</h3>
+          <div class="file">src/rmodels.c</div>
+          <p>Mesh loading (glTF, OBJ, IQM), materials, shaders, 3D draw calls.</p>
+        </a>
+        <a class="component-card" href="raudio.html">
+          <h3>raudio</h3>
+          <div class="file">src/raudio.c</div>
+          <p>miniaudio backend, streaming, mixing on a separate thread.</p>
+        </a>
+      </div>
+      <p>Header-only helpers included from <code>rcore.c</code>: <code>raymath.h</code> (vectors/matrices), <code>rcamera.h</code> (camera controllers), <code>rgestures.h</code> (touch gestures).</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>End-to-End Data Flow</summary>
+    <div class="details-body">
+      <div class="flow-diagram">USER CODE (main loop)
+  InitWindow() ──────────────────────────────────────────────┐
+  InitAudioDevice()  (optional, separate from graphics)      │
+                                                             ▼
+<span style="color:#7ec8ff">PLATFORM LAYER</span>  (rcore_desktop_glfw.c, rcore_web.c, …)
+  InitPlatform() → GLFW/SDL window + OpenGL context
+                                                             │
+<span style="color:#7ec8ff">GRAPHICS INIT</span>   (rcore.c)
+  rlglInit() → default shader, 1×1 white texture, render batch VBOs
+  LoadFontDefault() → glyph atlas texture (rtext)
+  SetShapesTexture() → share font white-pixel for shape batching (rshapes)
+                                                             │
+  ┌── while (!WindowShouldClose()) ──────────────────────────┤
+  │                                                          │
+  │  BeginDrawing()                                          │
+  │    · update frame timing                                 │
+  │    · reset modelview + screen scale                      │
+  │                                                          │
+  │  ClearBackground() → rlClearScreenBuffers()              │
+  │                                                          │
+  │  DrawRectangle / DrawTexture / DrawText / DrawModel …    │
+  │    · 2D: rlBegin → rlVertex* → rlEnd  (CPU batch)        │
+  │    · 3D: DrawMesh → shader uniforms + glDrawElements     │
+  │                                                          │
+  │  EndDrawing()                                            │
+  │    · rlDrawRenderBatchActive() → upload VBOs, glDraw*  │
+  │    · SwapScreenBuffer() → glfwSwapBuffers              │
+  │    · frame limiter + PollInputEvents()                   │
+  └──────────────────────────────────────────────────────────┘
+                                                             │
+  CloseWindow() → rlglClose() + ClosePlatform()</div>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Frame Loop Step by Step</summary>
+    <div class="details-body">
+      <div class="flow-steps">
+        <div class="flow-step">
+          <div class="flow-step-num">1</div>
+          <div class="flow-step-body">
+            <div class="flow-step-title"><a href="rcore.html">InitWindow</a> bootstraps everything</div>
+            <div class="flow-step-desc">Sets screen dimensions, calls <code>InitPlatform()</code> for OS window + GL context, then <code>rlglInit()</code> for GPU resources. Optionally loads the default font and wires it into the shapes module for texture batching.</div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="flow-step-num">2</div>
+          <div class="flow-step-body">
+            <div class="flow-step-title"><a href="rcore.html">BeginDrawing</a> starts a frame</div>
+            <div class="flow-step-desc">Records elapsed time, resets the modelview matrix, and applies HiDPI screen scaling. No GPU flush yet — draw calls accumulate in CPU-side batch buffers.</div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="flow-step-num">3</div>
+          <div class="flow-step-body">
+            <div class="flow-step-title">Draw calls enqueue vertices</div>
+            <div class="flow-step-desc"><a href="rshapes.html">rshapes</a> and <a href="rtextures.html">rtextures</a>/<a href="rtext.html">rtext</a> use <code>rlBegin/rlEnd</code> to append position, texcoord, color, and normal arrays. <a href="rmodels.html">rmodels</a> bypasses the batch and issues per-mesh shader draws when in 3D mode.</div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="flow-step-num">4</div>
+          <div class="flow-step-body">
+            <div class="flow-step-title"><a href="rlgl.html">rlDrawRenderBatchActive</a> flushes 2D</div>
+            <div class="flow-step-desc">Uploads batched vertex data with <code>glBufferSubData</code>, sets MVP uniforms, and issues draw calls grouped by texture/shader/mode. Also called when switching 2D↔3D or render targets.</div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="flow-step-num">5</div>
+          <div class="flow-step-body">
+            <div class="flow-step-title"><a href="rcore.html">EndDrawing</a> presents the frame</div>
+            <div class="flow-step-desc">Final batch flush, buffer swap (<code>glfwSwapBuffers</code>), frame-time limiter, and input polling. Audio runs independently on miniaudio's callback thread.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <details open>
+    <summary>2D vs 3D Rendering Paths</summary>
+    <div class="details-body">
+      <table>
+        <thead>
+          <tr><th>Aspect</th><th>2D (default)</th><th>3D (<code>BeginMode3D</code>)</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Projection</td><td>Orthographic, top-left origin</td><td>Perspective or ortho frustum from <code>Camera</code></td></tr>
+          <tr><td>Depth test</td><td>Disabled</td><td>Enabled</td></tr>
+          <tr><td>Draw path</td><td>Render batch (rlgl)</td><td>Per-mesh shader + VAO (<code>DrawMesh</code>)</td></tr>
+          <tr><td>Typical modules</td><td>rshapes, rtextures, rtext</td><td>rmodels (+ billboards via rtextures)</td></tr>
+          <tr><td>Mode switch</td><td colspan="2"><code>BeginMode3D</code> flushes batch, pushes projection matrix; <code>EndMode3D</code> restores 2D</td></tr>
+        </tbody>
+      </table>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L941-L993">BeginMode3D / EndMode3D</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>External References</summary>
+    <div class="details-body">
+      <ul class="ref-list">
+        <li><a href="https://www.raylib.com/cheatsheet/cheatsheet.html">raylib cheatsheet</a> — full public API at a glance</li>
+        <li><a href="https://www.khronos.org/opengl/">OpenGL specification (Khronos)</a> — the API rlgl wraps (1.1 legacy, 3.3 core, ES 2.0)</li>
+        <li><a href="https://learnopengl.com/Getting-started/Coordinate-Systems">LearnOpenGL — Coordinate Systems</a> — model/view/projection pipeline used in 3D mode</li>
+        <li><a href="https://www.glfw.org/docs/latest/">GLFW documentation</a> — default desktop window/context backend</li>
+        <li><a href="https://miniaud.io/docs/manual/index.html">miniaudio manual</a> — audio device callback model used by raudio</li>
+        <li><a href="https://github.com/nothings/stb">stb libraries</a> — image/font loading helpers bundled in rtextures/rtext</li>
+        <li><a href="https://github.com/raysan5/raylib/wiki">raylib wiki</a> — platform build notes and architecture discussions</li>
+      </ul>
+    </div>
+  </details>
+</main>
+
+</body>
+</html>

--- a/explainers/raylib-data-flow/raudio.html
+++ b/explainers/raylib-data-flow/raudio.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>raylib — raudio (Audio System)</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<nav class="site-nav">
+  <a class="brand" href="index.html">raylib Data Flow</a>
+  <a href="index.html">Overview</a>
+  <a href="rcore.html">rcore</a>
+  <a href="rlgl.html">rlgl</a>
+  <a href="rshapes.html">rshapes</a>
+  <a href="rtextures.html">rtextures</a>
+  <a href="rtext.html">rtext</a>
+  <a href="rmodels.html">rmodels</a>
+  <a href="raudio.html" class="active">raudio</a>
+</nav>
+
+<main>
+  <h1 class="page-title">raudio — Audio Loading &amp; Playback</h1>
+  <p class="page-subtitle"><code>src/raudio.c</code> wraps <a href="https://miniaud.io/">miniaudio</a> for device output. Audio runs on a separate callback thread from the graphics loop — no coupling with rlgl or the frame batch.</p>
+
+  <details open>
+    <summary>Architecture Overview</summary>
+    <div class="details-body">
+      <div class="flow-diagram">InitAudioDevice()
+  → ma_context_init + ma_device_init (playback)
+  → ma_device_start (device runs continuously)
+  → callback: OnSendAudioDataToDevice() on audio thread
+
+LoadSound("hit.wav")
+  → decode to Wave (CPU PCM) → Sound (AudioBuffer wrapper)
+
+PlaySound(sound)
+  → AudioBuffer.playing = true (mutex-protected)
+
+Each audio callback:
+  for each playing AudioBuffer in linked list:
+      read PCM frames → apply volume/pan/pitch → mix into output buffer</div>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/raudio.c#L465-L528">InitAudioDevice</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Device Initialization</summary>
+    <div class="details-body">
+      <pre><code>void InitAudioDevice(void)
+{
+    ma_context_init(..., &amp;AUDIO.System.context);
+    ma_device_config config = ma_device_config_init(ma_device_type_playback);
+    config.playback.format = AUDIO_DEVICE_FORMAT;   // float32
+    config.playback.channels = AUDIO_DEVICE_CHANNELS;
+    config.sampleRate = AUDIO_DEVICE_SAMPLE_RATE;
+    config.dataCallback = OnSendAudioDataToDevice;
+    config.noFixedSizedCallback = true;
+
+    ma_device_init(&amp;AUDIO.System.context, &amp;config, &amp;AUDIO.System.device);
+    ma_mutex_init(&amp;AUDIO.System.lock);
+    ma_device_start(&amp;AUDIO.System.device);
+}</code></pre>
+      <p>The device stays running for the app lifetime. Mixing uses float32 internally for headroom before conversion to the hardware format.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/raudio.c#L465-L528">InitAudioDevice</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Sound vs Music vs Stream</summary>
+    <div class="details-body">
+      <table>
+        <thead>
+          <tr><th>Type</th><th>Storage</th><th>Use case</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>Wave</code></td><td>Full PCM in RAM</td><td>Intermediate decode result</td></tr>
+          <tr><td><code>Sound</code></td><td>Short buffer, fully decoded</td><td>SFX — load once, play many times</td></tr>
+          <tr><td><code>Music</code></td><td>Streaming buffer (queue)</td><td>Long OGG/MP3 — reads chunks on the fly</td></tr>
+          <tr><td><code>AudioStream</code></td><td>User-filled buffer queue</td><td>Custom synthesis or procedural audio</td></tr>
+        </tbody>
+      </table>
+      <pre><code>Sound LoadSound(const char *fileName)
+{
+    Wave wave = LoadWave(fileName);
+    Sound sound = LoadSoundFromWave(wave);
+    UnloadWave(wave);
+    return sound;
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/raudio.c#L932-L945">LoadSound</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Playback Control</summary>
+    <div class="details-body">
+      <pre><code>void PlaySound(Sound sound)
+{
+    PlayAudioBuffer(sound.stream.buffer);
+}
+
+void PlayAudioBuffer(AudioBuffer *buffer)
+{
+    ma_mutex_lock(&amp;AUDIO.System.lock);
+    buffer->playing = true;
+    buffer->paused = false;
+    buffer->frameCursorPos = 0;
+    ma_mutex_unlock(&amp;AUDIO.System.lock);
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/raudio.c#L663-L676">PlayAudioBuffer</a>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/raudio.c#L1195-L1198">PlaySound</a>
+      <p>Volume, pitch, and pan mutate <code>AudioBuffer</code> fields under the same mutex. Pitch adjusts the sample-rate converter (<code>ma_data_converter</code>).</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Mixing Callback (Real-Time Path)</summary>
+    <div class="details-body">
+      <p>The audio device invokes this periodically to fill the output buffer:</p>
+      <pre><code>static void OnSendAudioDataToDevice(ma_device *pDevice,
+                                    void *pFramesOut, ...,
+                                    ma_uint32 frameCount)
+{
+    memset(pFramesOut, 0, ...);   // accumulation buffer
+
+    ma_mutex_lock(&amp;AUDIO.System.lock);
+    for (AudioBuffer *buf = AUDIO.Buffer.first; buf; buf = buf->next)
+    {
+        if (!buf->playing || buf->paused) continue;
+
+        ReadAudioBufferFramesInMixingFormat(buf, tempBuffer, framesToRead);
+        // optional processor chain (effects)
+        MixAudioFrames(output, tempBuffer, framesRead, buf);
+    }
+    ma_mutex_unlock(&amp;AUDIO.System.lock);
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/raudio.c#L2560-L2640">OnSendAudioDataToDevice</a>
+      <p>All active sounds mix additively into <code>pFramesOut</code>. When a non-looping buffer reaches its end, <code>StopAudioBufferInLockedState</code> clears <code>playing</code>.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Threading Model</summary>
+    <div class="details-body">
+      <p>Graphics run on the main thread; audio mixes on miniaudio's device thread. A mutex (<code>AUDIO.System.lock</code>) synchronizes buffer list mutations (play/stop) with the callback. Keep main-thread audio calls lightweight — don't decode large files during gameplay; preload or stream instead.</p>
+      <p>This is independent of <code>BeginDrawing</code>/<code>EndDrawing</code>. Typical game code calls <code>UpdateMusicStream</code> each frame to refill streaming buffers while the callback consumes them.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Decoders</summary>
+    <div class="details-body">
+      <p>raudio bundles decoders in <code>src/external/</code>:</p>
+      <ul>
+        <li>WAV — built-in</li>
+        <li>OGG — stb_vorbis / dr_flac paths</li>
+        <li>MP3, FLAC, XM/MOD — various embedded libraries</li>
+        <li>QOA — quick lossless audio format</li>
+      </ul>
+      <p>All decode to normalized PCM (<code>Wave</code>) before becoming a <code>Sound</code> or streaming queue.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Typical Game Integration</summary>
+    <div class="details-body">
+      <pre><code>InitWindow(800, 450, "game");
+InitAudioDevice();
+
+Sound jump = LoadSound("jump.wav");
+Music bgm = LoadMusicStream("theme.ogg");
+PlayMusicStream(bgm);
+
+while (!WindowShouldClose())
+{
+    UpdateMusicStream(bgm);     // refill stream buffers each frame
+
+    if (IsKeyPressed(KEY_SPACE)) PlaySound(jump);
+
+    BeginDrawing();
+        ClearBackground(RAYWHITE);
+        // ... draw ...
+    EndDrawing();
+}
+
+UnloadMusicStream(bgm);
+UnloadSound(jump);
+CloseAudioDevice();
+CloseWindow();</code></pre>
+    </div>
+  </details>
+
+  <details open>
+    <summary>External References</summary>
+    <div class="details-body">
+      <ul class="ref-list">
+        <li><a href="https://miniaud.io/docs/manual/index.html">miniaudio manual</a> — device model and callbacks</li>
+        <li><a href="https://miniaud.io/docs/api/index.html#low-level-api">miniaudio low-level API</a></li>
+        <li><a href="https://en.wikipedia.org/wiki/Pulse-code_modulation">PCM audio basics</a></li>
+        <li><a href="https://www.raylib.com/examples.html">raylib examples — audio category</a></li>
+      </ul>
+    </div>
+  </details>
+</main>
+
+</body>
+</html>

--- a/explainers/raylib-data-flow/rcore.html
+++ b/explainers/raylib-data-flow/rcore.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>raylib — rcore (Window &amp; Frame Loop)</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<nav class="site-nav">
+  <a class="brand" href="index.html">raylib Data Flow</a>
+  <a href="index.html">Overview</a>
+  <a href="rcore.html" class="active">rcore</a>
+  <a href="rlgl.html">rlgl</a>
+  <a href="rshapes.html">rshapes</a>
+  <a href="rtextures.html">rtextures</a>
+  <a href="rtext.html">rtext</a>
+  <a href="rmodels.html">rmodels</a>
+  <a href="raudio.html">raudio</a>
+</nav>
+
+<main>
+  <h1 class="page-title">rcore — Window, Input &amp; Frame Loop</h1>
+  <p class="page-subtitle"><code>src/rcore.c</code> plus platform files under <code>src/platforms/</code>. Owns the global <code>CORE</code> state, orchestrates initialization, the per-frame loop, 2D/3D mode switches, and render-target binding.</p>
+
+  <details open>
+    <summary>Responsibilities</summary>
+    <div class="details-body">
+      <ul>
+        <li>Window lifecycle: <code>InitWindow</code>, <code>CloseWindow</code>, fullscreen, HiDPI scaling</li>
+        <li>Input state: keyboard, mouse, gamepad, touch (via platform callbacks)</li>
+        <li>Timing: frame counter, target FPS, <code>GetFrameTime()</code></li>
+        <li>Drawing orchestration: <code>BeginDrawing</code>, <code>EndDrawing</code>, <code>ClearBackground</code></li>
+        <li>3D context: <code>BeginMode3D</code> / <code>EndMode3D</code> projection + depth setup</li>
+        <li>Off-screen rendering: <code>BeginTextureMode</code> / <code>EndTextureMode</code> (FBO)</li>
+        <li>Includes and initializes rlgl, raymath, optional rcamera/rgestures</li>
+      </ul>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L1-L90">rcore.c module header</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Initialization Sequence</summary>
+    <div class="details-body">
+      <p><code>InitWindow</code> is the single entry point that wires every graphics subsystem together:</p>
+      <pre><code>void InitWindow(int width, int height, const char *title)
+{
+    // 1. Store screen size, reset CORE.Input
+    CORE.Window.screen.width = width;
+    CORE.Window.screen.height = height;
+
+    // 2. Platform: create OS window + OpenGL context
+    int result = InitPlatform();   // → rcore_desktop_glfw.c on desktop
+
+    // 3. GPU layer: shaders, default texture, render batch
+    rlglInit(CORE.Window.render.width, CORE.Window.render.height);
+    SetupViewport(CORE.Window.render.width, CORE.Window.render.height);
+
+    // 4. Default font + shapes texture sharing (enables 2D batching)
+    LoadFontDefault();
+    SetShapesTexture(GetFontDefault().texture, ...);
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L585-L720">InitWindow full source</a>
+      <h3>Platform layer (InitPlatform)</h3>
+      <p>On desktop GLFW builds, <code>InitPlatform</code> initializes GLFW, creates the window with requested flags (resizable, MSAA, transparent, etc.), and creates the OpenGL context. Different platform files swap this backend:</p>
+      <ul>
+        <li><span class="tag">rcore_desktop_glfw.c</span> Windows, Linux, macOS</li>
+        <li><span class="tag">rcore_desktop_sdl.c</span> SDL backend</li>
+        <li><span class="tag">rcore_web.c</span> Emscripten / HTML5</li>
+        <li><span class="tag">rcore_android.c</span> Android NDK</li>
+        <li><span class="tag">rcore_drm.c</span> Raspberry Pi KMS/DRM</li>
+      </ul>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/platforms/rcore_desktop_glfw.c#L1436-L1515">InitPlatform (GLFW)</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Per-Frame Loop</summary>
+    <div class="details-body">
+      <pre><code>void BeginDrawing(void)
+{
+    CORE.Time.current = GetTime();
+    CORE.Time.update = CORE.Time.current - CORE.Time.previous;
+    CORE.Time.previous = CORE.Time.current;
+
+    rlLoadIdentity();
+    rlMultMatrixf(MatrixToFloat(CORE.Window.screenScale));
+}
+
+void EndDrawing(void)
+{
+    rlDrawRenderBatchActive();     // flush accumulated 2D vertices
+
+    SwapScreenBuffer();            // glfwSwapBuffers / platform equivalent
+
+    // Frame limiter: sleep until target frame time reached
+    if (CORE.Time.frame &lt; CORE.Time.target)
+        WaitTime(CORE.Time.target - CORE.Time.frame);
+
+    PollInputEvents();             // keyboard/mouse/gamepad update
+    CORE.Time.frameCounter++;
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L858-L904">BeginDrawing / EndDrawing</a>
+      <p>The split between <code>update</code> and <code>draw</code> timing lets you measure logic vs rendering separately. <code>SetTargetFPS</code> sets <code>CORE.Time.target</code> for the sleep in <code>EndDrawing</code>.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>3D Mode Switching</summary>
+    <div class="details-body">
+      <p>2D drawing uses an orthographic projection set up in <code>SetupViewport</code>. Entering 3D mode must flush any pending 2D batch first, then replace the projection matrix:</p>
+      <pre><code>void BeginMode3D(Camera camera)
+{
+    rlDrawRenderBatchActive();          // flush 2D batch before 3D
+
+    rlMatrixMode(RL_PROJECTION);
+    rlPushMatrix();                     // save 2D projection
+    rlLoadIdentity();
+
+    if (camera.projection == CAMERA_PERSPECTIVE)
+        rlFrustum(-right, right, -top, top, near, far);
+    else
+        rlOrtho(-right, right, -top, top, near, far);
+
+    rlMatrixMode(RL_MODELVIEW);
+    rlLoadIdentity();
+    rlMultMatrixf(MatrixToFloat(MatrixLookAt(...)));
+    rlEnableDepthTest();
+}</code></pre>
+      <p><code>EndMode3D</code> flushes again, pops the saved projection, disables depth test, and restores 2D screen scaling.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L941-L993">BeginMode3D / EndMode3D</a>
+      <p>See also: <a href="https://learnopengl.com/Getting-started/Coordinate-Systems">LearnOpenGL — Coordinate Systems</a> for the view/projection math.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Render Targets (FBO)</summary>
+    <div class="details-body">
+      <p><code>BeginTextureMode</code> redirects drawing to an off-screen framebuffer created by <code>LoadRenderTexture</code> in rtextures. It flushes the current batch, binds the FBO, sets an orthographic projection to the texture size, and tracks <code>CORE.Window.usingFbo</code>.</p>
+      <pre><code>void BeginTextureMode(RenderTexture2D target)
+{
+    rlDrawRenderBatchActive();
+    rlEnableFramebuffer(target.id);
+    rlViewport(0, 0, target.texture.width, target.texture.height);
+    rlOrtho(0, target.texture.width, target.texture.height, 0, 0.0f, 1.0f);
+    CORE.Window.usingFbo = true;
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L996-L1040">BeginTextureMode / EndTextureMode</a>
+      <p>Typical use: render a scene to a texture, then draw that texture as a sprite in 2D. Details in <a href="rtextures.html">rtextures</a>.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>How rcore Connects to Other Modules</summary>
+    <div class="details-body">
+      <div class="flow-diagram">InitWindow
+  ├── InitPlatform()          platform/*.c  → OS window, GL context, input callbacks
+  ├── rlglInit()              rlgl.h        → GPU init (see rlgl.html)
+  ├── LoadFontDefault()       rtext.c       → default glyph atlas
+  └── SetShapesTexture()      rshapes.c     → shared 1×1 white region for batching
+
+BeginDrawing / EndDrawing
+  └── rlDrawRenderBatchActive()  rlgl.h     → flush 2D vertices
+
+BeginMode3D
+  └── DrawModel()             rmodels.c     → 3D mesh draws (separate from batch)
+
+InitAudioDevice()             raudio.c      → independent of graphics init</div>
+      <p>Audio is intentionally separate: call <code>InitAudioDevice()</code> yourself. It does not happen inside <code>InitWindow</code>.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>External References</summary>
+    <div class="details-body">
+      <ul class="ref-list">
+        <li><a href="https://www.glfw.org/docs/latest/quick.html">GLFW Quick Guide</a> — window + context creation model</li>
+        <li><a href="https://github.com/raysan5/raylib/wiki/raylib-architecture">raylib wiki — architecture</a></li>
+        <li><a href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/config.h">config.h</a> — compile-time module and platform flags</li>
+      </ul>
+    </div>
+  </details>
+</main>
+
+</body>
+</html>

--- a/explainers/raylib-data-flow/rlgl.html
+++ b/explainers/raylib-data-flow/rlgl.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>raylib — rlgl (OpenGL Abstraction)</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<nav class="site-nav">
+  <a class="brand" href="index.html">raylib Data Flow</a>
+  <a href="index.html">Overview</a>
+  <a href="rcore.html">rcore</a>
+  <a href="rlgl.html" class="active">rlgl</a>
+  <a href="rshapes.html">rshapes</a>
+  <a href="rtextures.html">rtextures</a>
+  <a href="rtext.html">rtext</a>
+  <a href="rmodels.html">rmodels</a>
+  <a href="raudio.html">raudio</a>
+</nav>
+
+<main>
+  <h1 class="page-title">rlgl — OpenGL Abstraction &amp; Render Batching</h1>
+  <p class="page-subtitle"><code>src/rlgl.h</code> is a header-only OpenGL wrapper included from <code>rcore.c</code> with <code>#define RLGL_IMPLEMENTATION</code>. It targets OpenGL 1.1 (fixed function), 3.3+ core, and ES 2.0 from a single API.</p>
+
+  <details open>
+    <summary>Why rlgl Exists</summary>
+    <div class="details-body">
+      <p>raylib modules never call OpenGL directly (except inside rlgl). This gives:</p>
+      <ul>
+        <li>One codebase for desktop GL 3.3, legacy GL 1.1, OpenGL ES 2.0, and a software renderer</li>
+        <li>Immediate-mode style API (<code>rlBegin</code>/<code>rlVertex2f</code>/<code>rlEnd</code>) that feeds a modern VBO batch on GL 3.3</li>
+        <li>Centralized shader management, texture binding, and matrix stacks</li>
+      </ul>
+      <p>rlgl can also be extracted as a standalone module — see the <a href="https://github.com/raysan5/raylib/blob/master/src/rlgl.h">rlgl header docs</a>.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rlgl.h#L1-L30">rlgl.h introduction</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Initialization (rlglInit)</summary>
+    <div class="details-body">
+      <p>Called from <code>InitWindow</code> after the platform creates an OpenGL context:</p>
+      <pre><code>void rlglInit(int width, int height)
+{
+    // 1×1 white default texture (used when no texture bound)
+    RLGL.State.defaultTextureId = rlLoadTexture(pixels, 1, 1, ...);
+
+    // Built-in 2D shader (GL 3.3 / ES2)
+    rlLoadShaderDefault();
+
+    // CPU-side vertex batch + GPU VBOs/VAO
+    RLGL.defaultBatch = rlLoadRenderBatch(
+        RL_DEFAULT_BATCH_BUFFERS,
+        RL_DEFAULT_BATCH_BUFFER_ELEMENTS);
+    RLGL.currentBatch = &amp;RLGL.defaultBatch;
+
+    // Matrix stacks (emulating GL 1.1 push/pop)
+    RLGL.State.projection = rlMatrixIdentity();
+    RLGL.State.modelview = rlMatrixIdentity();
+
+    // GL state defaults
+    glEnable(GL_BLEND);
+    glDisable(GL_DEPTH_TEST);   // 2D mode default
+    glEnable(GL_CULL_FACE);
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rlgl.h#L2285-L2360">rlglInit</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Render Batch — Core Data Flow</summary>
+    <div class="details-body">
+      <p>All 2D draw calls (shapes, textures, text) funnel through the same batch. Instead of one GPU draw call per rectangle, vertices accumulate in CPU arrays and flush together.</p>
+      <div class="flow-diagram">DrawRectangle / DrawTexturePro / DrawTextCodepoint
+        │
+        ▼
+  rlSetTexture(id)          ← texture change may flush batch
+  rlBegin(RL_QUADS)
+  rlColor4ub / rlTexCoord2f / rlVertex2f   ← append to CPU arrays
+  rlEnd()
+        │
+        ▼  (deferred until flush)
+  rlDrawRenderBatch(batch)
+    1. glBufferSubData → upload vertices, texcoords, colors, normals
+    2. glUseProgram(defaultShader)
+    3. glUniformMatrix4fv(MVP)
+    4. For each draw group: bind texture → glDrawArrays</div>
+
+      <h3>Vertex accumulation (rlVertex3f)</h3>
+      <p>Each <code>rlVertex*</code> call writes position, current texcoord, normal, and color into the active buffer slot, then increments <code>RLGL.State.vertexCounter</code>:</p>
+      <pre><code>RLGL.currentBatch->vertexBuffer[...].vertices[3*counter] = tx;
+RLGL.currentBatch->vertexBuffer[...].texcoords[2*counter] = texcoordx;
+RLGL.currentBatch->vertexBuffer[...].colors[4*counter] = colorr;
+RLGL.State.vertexCounter++;</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rlgl.h#L1522-L1581">rlVertex3f</a>
+
+      <h3>Batch flush (rlDrawRenderBatch)</h3>
+      <p>Uploads all pending vertices and iterates draw groups (each group shares texture, primitive mode, and shader):</p>
+      <pre><code>void rlDrawRenderBatch(rlRenderBatch *batch)
+{
+    glBufferSubData(..., batch->vertices);
+    glBufferSubData(..., batch->texcoords);
+    glBufferSubData(..., batch->colors);
+
+    glUseProgram(RLGL.State.currentShaderId);
+    Matrix matMVP = rlMatrixMultiply(modelview, projection);
+    glUniformMatrix4fv(..., matMVP);
+
+    // per draw-call: bind texture, glDrawArrays(mode, offset, count)
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rlgl.h#L2985-L3100">rlDrawRenderBatch</a>
+      <p><code>rlDrawRenderBatchActive()</code> is called at <code>EndDrawing</code>, mode switches, and texture changes — anything that would break batch coherency.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>When the Batch Flushes Early</summary>
+    <div class="details-body">
+      <p>The batch splits (issues an intermediate draw) when:</p>
+      <ul>
+        <li>Vertex buffer capacity is reached</li>
+        <li>Texture ID changes (<code>rlSetTexture</code> with a different bound texture)</li>
+        <li>Shader changes (3D <code>DrawMesh</code> uses custom shaders)</li>
+        <li>Draw call count exceeds <code>RL_DEFAULT_BATCH_DRAWCALLS</code></li>
+        <li><code>BeginMode3D</code>, <code>BeginTextureMode</code>, or <code>EndDrawing</code> explicitly flush</li>
+      </ul>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rlgl.h#L1665-L1711">rlSetTexture flush logic</a>
+      <p>Understanding flush points explains draw-order bugs: mixing 3D mesh draws with unflushed 2D batch data requires explicit mode boundaries from rcore.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Matrix Stack</summary>
+    <div class="details-body">
+      <p>rlgl emulates OpenGL 1.1 matrix stacks for 2D transforms. <code>rlPushMatrix</code>/<code>rlPopMatrix</code> operate on the active matrix (modelview by default). <code>DrawTextPro</code> uses this for rotation around an origin.</p>
+      <p>On GL 3.3, matrices are stored in software (<code>RLGL.State.modelview</code>, <code>RLGL.State.projection</code>) and uploaded as uniforms — there is no fixed-function pipeline.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rlgl.h#L1228-L1349">Matrix operations (GL 3.3 path)</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>3D vs 2D in rlgl</summary>
+    <div class="details-body">
+      <table>
+        <thead>
+          <tr><th>2D batch path</th><th>3D mesh path</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>rlBegin</code> / <code>rlEnd</code></td><td><code>rlEnableShader</code> + VAO + <code>glDrawElements</code></td></tr>
+          <tr><td>Default 2D shader</td><td>Per-material custom shader (lighting, PBR)</td></tr>
+          <tr><td>Shared VBO ring buffer</td><td>Per-mesh vertex/index buffers uploaded at load time</td></tr>
+          <tr><td>Used by rshapes, rtextures, rtext</td><td>Used by rmodels (<code>DrawMesh</code>)</td></tr>
+        </tbody>
+      </table>
+      <p>See <a href="rmodels.html">rmodels</a> for the shader uniform upload path that bypasses the batch.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>External References</summary>
+    <div class="details-body">
+      <ul class="ref-list">
+        <li><a href="https://www.khronos.org/opengl/wiki/Vertex_Specification">OpenGL Wiki — Vertex Specification</a> — VBO/VAO model used by the batch</li>
+        <li><a href="https://learnopengl.com/Getting-started/Hello-Triangle">LearnOpenGL — Hello Triangle</a> — shader + draw call basics</li>
+        <li><a href="https://github.com/raysan5/raylib/wiki/raylib-opengl-abstraction-layer">raylib wiki — OpenGL abstraction layer</a></li>
+        <li><a href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rlgl.h#L415-L424">rlRenderBatch struct</a></li>
+      </ul>
+    </div>
+  </details>
+</main>
+
+</body>
+</html>

--- a/explainers/raylib-data-flow/rmodels.html
+++ b/explainers/raylib-data-flow/rmodels.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>raylib — rmodels (3D Models &amp; Meshes)</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<nav class="site-nav">
+  <a class="brand" href="index.html">raylib Data Flow</a>
+  <a href="index.html">Overview</a>
+  <a href="rcore.html">rcore</a>
+  <a href="rlgl.html">rlgl</a>
+  <a href="rshapes.html">rshapes</a>
+  <a href="rtextures.html">rtextures</a>
+  <a href="rtext.html">rtext</a>
+  <a href="rmodels.html" class="active">rmodels</a>
+  <a href="raudio.html">raudio</a>
+</nav>
+
+<main>
+  <h1 class="page-title">rmodels — 3D Models, Meshes &amp; Materials</h1>
+  <p class="page-subtitle"><code>src/rmodels.c</code> loads 3D assets (glTF, OBJ, IQM, M3D, etc.), uploads mesh data to GPU buffers, and draws with per-material shaders — outside the 2D render batch.</p>
+
+  <details open>
+    <summary>Core Types</summary>
+    <div class="details-body">
+      <table>
+        <thead>
+          <tr><th>Type</th><th>Contents</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>Mesh</code></td><td>Vertex positions, normals, texcoords, colors, indices; optional animation data (bones, weights)</td></tr>
+          <tr><td><code>Material</code></td><td><code>Shader</code> + up to 12 texture maps (diffuse, normal, PBR maps…) + colors</td></tr>
+          <tr><td><code>Model</code></td><td>Array of meshes, materials, mesh→material index, transform matrix, skeleton</td></tr>
+          <tr><td><code>ModelAnimation</code></td><td>Skeletal keyframes for animated glTF/IQM models</td></tr>
+        </tbody>
+      </table>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/raylib.h#L200-L350">Model/Mesh/Material structs in raylib.h</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Loading Pipeline</summary>
+    <div class="details-body">
+      <div class="flow-diagram">LoadModel("scene.gltf")
+  → format-specific loader (cgltf, tinyobj, etc.)
+      │
+      ├─ parse file → Mesh[] (CPU arrays)
+      ├─ parse materials → textures via LoadTexture (rtextures)
+      ├─ assign default lit shader (or PBR shader)
+      └─ UploadMesh() → glGenBuffers, glBufferData (VAO/VBO/IBO)
+
+Model ready: meshes live on GPU, materials hold texture IDs</div>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rmodels.c#L1102-L1150">LoadModel / LoadModelFromMesh</a>
+      <p>glTF loading uses <code>cgltf.h</code> in <code>src/external/</code>. Each mesh uploads once; drawing reuses GPU buffers.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Drawing Pipeline</summary>
+    <div class="details-body">
+      <p>3D drawing requires <code>BeginMode3D</code> first (see <a href="rcore.html">rcore</a>). Then:</p>
+      <pre><code>void DrawModelEx(Model model, Vector3 position, Vector3 axis,
+                 float angle, Vector3 scale, Color tint)
+{
+    // Build transform: scale → rotate → translate
+    Matrix matTransform = MatrixMultiply(
+        MatrixMultiply(MatrixScale(...), MatrixRotate(...)),
+        MatrixTranslate(...));
+    model.transform = MatrixMultiply(model.transform, matTransform);
+
+    for each mesh i:
+        Material mat = model.materials[model.meshMaterial[i]];
+        apply tint to diffuse color
+        upload bone matrices if skeletal animation
+        DrawMesh(model.meshes[i], mat, model.transform);
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rmodels.c#L3922-L3962">DrawModelEx</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>DrawMesh — Shader &amp; GPU Path</summary>
+    <div class="details-body">
+      <p>Unlike 2D shapes, <code>DrawMesh</code> bypasses the vertex batch. It binds the material's shader, uploads matrices and material uniforms, binds texture maps, and calls <code>glDrawElements</code>:</p>
+      <pre><code>void DrawMesh(Mesh mesh, Material material, Matrix transform)
+{
+    rlEnableShader(material.shader.id);
+
+    // Upload diffuse/specular colors as uniforms
+    rlSetUniform(SHADER_LOC_COLOR_DIFFUSE, ...);
+
+    // Model / view / projection / normal matrices
+    Matrix matModel = MatrixMultiply(transform, rlGetMatrixTransform());
+    rlSetUniformMatrix(SHADER_LOC_MATRIX_MODEL, matModel);
+    rlSetUniformMatrix(SHADER_LOC_MATRIX_VIEW, rlGetMatrixModelview());
+    rlSetUniformMatrix(SHADER_LOC_MATRIX_PROJECTION, rlGetMatrixProjection());
+
+    // Bind each material map to texture slot i
+    for each map with texture.id > 0:
+        rlActiveTextureSlot(i);
+        rlEnableTexture(map.texture.id);
+
+    // Draw indexed triangles from mesh VAO
+    glBindVertexArray(mesh.vaoId);
+    glDrawElements(GL_TRIANGLES, mesh.triangleCount*3, ...);
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rmodels.c#L1478-L1580">DrawMesh (GL 3.3 path)</a>
+      <p>Each mesh draw may flush the 2D batch first if a prior <code>rlSetTexture</code> left pending vertices — another reason rcore calls <code>rlDrawRenderBatchActive</code> at mode boundaries.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Procedural 3D Shapes</summary>
+    <div class="details-body">
+      <p>rmodels also generates meshes for primitives: <code>GenMeshCube</code>, <code>GenMeshSphere</code>, <code>GenMeshPlane</code>, heightmaps, etc. These build CPU vertex arrays then call <code>UploadMesh</code> — same draw path as loaded assets.</p>
+      <p>Wireframe overlays use <code>rlEnableWireMode()</code> around <code>DrawModel</code>.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rmodels.c#L3966-L3983">DrawModelWires</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Billboards</summary>
+    <div class="details-body">
+      <p><code>DrawBillboard*</code> functions orient a textured quad toward the camera using the view matrix from <code>BeginMode3D</code>. They still use the 2D textured-quad path (<code>DrawTexturePro</code> style logic in 3D space) rather than <code>DrawMesh</code>.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rmodels.c#L4003-L4050">DrawBillboardPro</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Skeletal Animation</summary>
+    <div class="details-body">
+      <p>For animated models, <code>UpdateModelAnimation</code> computes bone transform matrices each frame into <code>model.boneMatrices</code>. <code>DrawModelEx</code> uploads them to <code>SHADER_LOC_MATRIX_BONETRANSFORMS</code> for GPU skinning in the vertex shader.</p>
+      <p>Animation data comes from glTF skins or IQM files at load time.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Connections</summary>
+    <div class="details-body">
+      <ul>
+        <li><a href="rcore.html">rcore</a> — <code>BeginMode3D</code> sets view/projection; depth test enabled</li>
+        <li><a href="rlgl.html">rlgl</a> — shader enable, uniform upload, texture slots; separate from batch</li>
+        <li><a href="rtextures.html">rtextures</a> — material diffuse/normal/etc. maps are <code>Texture2D</code> values</li>
+        <li><code>raymath.h</code> — <code>MatrixLookAt</code>, <code>MatrixMultiply</code>, quaternion helpers for transforms</li>
+      </ul>
+    </div>
+  </details>
+
+  <details open>
+    <summary>External References</summary>
+    <div class="details-body">
+      <ul class="ref-list">
+        <li><a href="https://learnopengl.com/Getting-started/Coordinate-Systems">LearnOpenGL — Coordinate Systems</a></li>
+        <li><a href="https://learnopengl.com/Lighting/Basic-Lighting">LearnOpenGL — Basic Lighting</a> — matches default lit shader concepts</li>
+        <li><a href="https://github.com/jkuhlmann/cgltf">cgltf</a> — glTF loader used internally</li>
+        <li><a href="https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html">glTF 2.0 specification</a></li>
+        <li><a href="https://www.raylib.com/examples.html">raylib examples — models category</a></li>
+      </ul>
+    </div>
+  </details>
+</main>
+
+</body>
+</html>

--- a/explainers/raylib-data-flow/rshapes.html
+++ b/explainers/raylib-data-flow/rshapes.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>raylib — rshapes (2D Primitives)</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<nav class="site-nav">
+  <a class="brand" href="index.html">raylib Data Flow</a>
+  <a href="index.html">Overview</a>
+  <a href="rcore.html">rcore</a>
+  <a href="rlgl.html">rlgl</a>
+  <a href="rshapes.html" class="active">rshapes</a>
+  <a href="rtextures.html">rtextures</a>
+  <a href="rtext.html">rtext</a>
+  <a href="rmodels.html">rmodels</a>
+  <a href="raudio.html">raudio</a>
+</nav>
+
+<main>
+  <h1 class="page-title">rshapes — 2D Primitives</h1>
+  <p class="page-subtitle"><code>src/rshapes.c</code> implements immediate-mode 2D drawing: pixels, lines, circles, rectangles, polygons, splines. Every function computes vertex positions in CPU and submits them through rlgl's batch.</p>
+
+  <details open>
+    <summary>Drawing Pipeline</summary>
+    <div class="details-body">
+      <div class="flow-diagram">DrawRectangle(x, y, w, h, color)
+  → DrawRectangleV → DrawRectanglePro
+      │
+      ├─ compute 4 corner vertices (rotation optional)
+      │
+      ├─ rlSetTexture(shapesTexture.id)   ← white pixel from default font atlas
+      ├─ rlBegin(RL_QUADS)
+      │     rlColor4ub(...)
+      │     rlTexCoord2f(...)  rlVertex2f(...)  × 4
+      └─ rlEnd()
+            │
+            ▼ (batched until flush — see rlgl.html)</div>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rshapes.c#L719-L816">DrawRectanglePro</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Why Shapes Use a Texture</summary>
+    <div class="details-body">
+      <p>Even solid-color rectangles go through the textured quad path. At init, rcore calls <code>SetShapesTexture</code> with a 1×1 white region from the default font atlas. This lets shapes, text, and textures share the same shader and batch — only the source texture atlas differs.</p>
+      <pre><code>// InitWindow (rcore.c) wires font white pixel into shapes:
+SetShapesTexture(GetFontDefault().texture, (Rectangle){ rec.x+1, rec.y+1, ... });</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L685-L702">SetShapesTexture at init</a>
+      <p>When rtext is disabled, rshapes falls back to rlgl's 1×1 default texture instead.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Primitive Types</summary>
+    <div class="details-body">
+      <table>
+        <thead>
+          <tr><th>Category</th><th>Functions</th><th>rlgl mode</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Pixels</td><td><code>DrawPixel</code></td><td><code>RL_POINTS</code></td></tr>
+          <tr><td>Lines</td><td><code>DrawLine</code>, <code>DrawLineEx</code>, <code>DrawLineBezier</code></td><td><code>RL_LINES</code> / triangles for thick lines</td></tr>
+          <tr><td>Circles</td><td><code>DrawCircle</code>, <code>DrawCircleSector</code></td><td>Triangle fan approximated as <code>RL_TRIANGLES</code></td></tr>
+          <tr><td>Rects</td><td><code>DrawRectangle</code>, gradients, rounded</td><td><code>RL_QUADS</code> or <code>RL_TRIANGLES</code></td></tr>
+          <tr><td>Polygons</td><td><code>DrawPoly</code>, <code>DrawSpline*</code></td><td>Custom vertex loops</td></tr>
+        </tbody>
+      </table>
+      <p>Circles and arcs tessellate into triangle segments. The <code>segments</code> parameter controls smoothness vs vertex count.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Example: Filled Rectangle</summary>
+    <div class="details-body">
+      <pre><code>void DrawRectanglePro(Rectangle rec, Vector2 origin, float rotation, Color color)
+{
+    // 1. Compute 4 corners (with optional rotation matrix)
+    Vector2 topLeft, topRight, bottomLeft, bottomRight;
+
+    // 2. Submit as textured quad
+    rlSetTexture(GetShapesTexture().id);
+    rlBegin(RL_QUADS);
+        rlColor4ub(color.r, color.g, color.b, color.a);
+        rlTexCoord2f(...); rlVertex2f(topLeft.x, topLeft.y);
+        rlTexCoord2f(...); rlVertex2f(bottomLeft.x, bottomLeft.y);
+        rlTexCoord2f(...); rlVertex2f(bottomRight.x, bottomRight.y);
+        rlTexCoord2f(...); rlVertex2f(topRight.x, topRight.y);
+    rlEnd();
+    rlSetTexture(0);
+}</code></pre>
+      <p>Gradient rectangles set per-vertex colors with different <code>rlColor4ub</code> calls before each vertex — the default shader interpolates color across the quad.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rshapes.c#L831-L863">DrawRectangleGradientEx</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Collision Helpers</summary>
+    <div class="details-body">
+      <p>rshapes also provides pure-CPU geometry helpers used by game logic (not GPU): <code>CheckCollisionRecs</code>, <code>CheckCollisionCircles</code>, <code>CheckCollisionPointRec</code>, etc. These read rectangle/circle parameters directly — no rlgl involvement.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rshapes.c#L2300-L2400">collision functions region</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Connections</summary>
+    <div class="details-body">
+      <ul>
+        <li><strong>Upstream:</strong> <a href="rcore.html">rcore</a> sets shapes texture at init; <a href="rlgl.html">rlgl</a> batches vertices</li>
+        <li><strong>Parallel:</strong> <a href="rtextures.html">rtextures</a> draws images the same way (textured quads) — shapes just use a solid white texel</li>
+        <li><strong>Shared path with text:</strong> <a href="rtext.html">rtext</a> ultimately calls <code>DrawTexturePro</code> for each glyph</li>
+      </ul>
+    </div>
+  </details>
+
+  <details open>
+    <summary>External References</summary>
+    <div class="details-body">
+      <ul class="ref-list">
+        <li><a href="https://en.wikipedia.org/wiki/Polygon_triangulation">Polygon triangulation</a> — how circles/arcs become triangle fans</li>
+        <li><a href="https://www.raylib.com/examples.html">raylib examples — shapes category</a></li>
+      </ul>
+    </div>
+  </details>
+</main>
+
+</body>
+</html>

--- a/explainers/raylib-data-flow/rtext.html
+++ b/explainers/raylib-data-flow/rtext.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>raylib — rtext (Fonts &amp; Text)</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<nav class="site-nav">
+  <a class="brand" href="index.html">raylib Data Flow</a>
+  <a href="index.html">Overview</a>
+  <a href="rcore.html">rcore</a>
+  <a href="rlgl.html">rlgl</a>
+  <a href="rshapes.html">rshapes</a>
+  <a href="rtextures.html">rtextures</a>
+  <a href="rtext.html" class="active">rtext</a>
+  <a href="rmodels.html">rmodels</a>
+  <a href="raudio.html">raudio</a>
+</nav>
+
+<main>
+  <h1 class="page-title">rtext — Fonts &amp; Text Rendering</h1>
+  <p class="page-subtitle"><code>src/rtext.c</code> loads fonts (TTF, sprite fonts, etc.), builds a GPU glyph atlas (<code>Font.texture</code>), and renders strings as a sequence of textured quads — the same 2D batch path as textures.</p>
+
+  <details open>
+    <summary>Font Structure</summary>
+    <div class="details-body">
+      <p>A <code>Font</code> is not a GPU object by itself — it bundles metadata plus one atlas texture:</p>
+      <ul>
+        <li><code>texture</code> — <code>Texture2D</code> atlas containing all glyph bitmaps</li>
+        <li><code>recs[]</code> — source rectangle in atlas per glyph index</li>
+        <li><code>glyphs[]</code> — advance, offset, and codepoint mapping</li>
+        <li><code>baseSize</code> — reference pixel height for scaling</li>
+      </ul>
+      <p>At startup, rcore calls <code>LoadFontDefault()</code> which embeds a small bitmap font (DejaVu-derived) so <code>DrawText</code> works without loading external files.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rtext.c#L337-L405">LoadFont / LoadFontEx</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Font Loading Flow</summary>
+    <div class="details-body">
+      <div class="flow-diagram">LoadFont("myfont.ttf")
+  → LoadFontEx(file, fontSize, codepoints, count)
+      │
+      ├─ stb_truetype / external decoder → rasterize glyphs to bitmap
+      ├─ pack glyphs into atlas Image (CPU)
+      ├─ LoadTextureFromImage(atlas)  → Font.texture (GPU)
+      └─ fill recs[], glyphs[] with metrics</div>
+      <p>TTF loading uses <code>stb_truetype</code> (in <code>src/external/</code>). You can restrict codepoints with <code>LoadFontEx</code> to keep atlas size small — important for CJK.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rtext.c#L387-L405">LoadFontEx</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Text Drawing Flow</summary>
+    <div class="details-body">
+      <pre><code>void DrawText(const char *text, int posX, int posY, int fontSize, Color color)
+{
+    DrawTextEx(GetFontDefault(), text, position, fontSize, spacing, color);
+}
+
+void DrawTextEx(Font font, const char *text, Vector2 position, ...)
+{
+    for each UTF-8 codepoint in text:
+        if codepoint == '\n' → advance line
+        else DrawTextCodepoint(font, codepoint, position + offset, ...);
+}
+
+void DrawTextCodepoint(Font font, int codepoint, Vector2 position, ...)
+{
+    int index = GetGlyphIndex(font, codepoint);
+    Rectangle srcRec = font.recs[index];     // atlas region
+    Rectangle dstRec = { position + offset, scaled size };
+    DrawTexturePro(font.texture, srcRec, dstRec, {0,0}, 0, tint);
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rtext.c#L1193-L1285">DrawText → DrawTextCodepoint</a>
+      <p>Each character is one <code>DrawTexturePro</code> call → four vertices in the rlgl batch. Long strings mean many quads but still batched by texture (single atlas = efficient).</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>UTF-8 Handling</summary>
+    <div class="details-body">
+      <p><code>GetCodepointNext</code> walks the input byte string, decoding UTF-8 into Unicode codepoints. <code>GetGlyphIndex</code> maps a codepoint to an atlas index, falling back to <code>'?'</code> for missing glyphs.</p>
+      <p>Spacing uses <code>glyphs[index].advanceX</code> scaled by <code>fontSize / baseSize</code>. Line breaks respect <code>textLineSpacing</code> (set via <code>SetTextLineSpacing</code>).</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Rotated Text</summary>
+    <div class="details-body">
+      <pre><code>void DrawTextPro(Font font, const char *text, Vector2 position,
+                 Vector2 origin, float rotation, ...)
+{
+    rlPushMatrix();
+        rlTranslatef(position.x, position.y, 0);
+        rlRotatef(rotation, 0, 0, 1);
+        rlTranslatef(-origin.x, -origin.y, 0);
+        DrawTextEx(font, text, (Vector2){0, 0}, ...);
+    rlPopMatrix();
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rtext.c#L1250-L1261">DrawTextPro</a>
+      <p>Uses rlgl's matrix stack — vertices are transformed before entering the batch when <code>transformRequired</code> is set.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Text Measurement (CPU)</summary>
+    <div class="details-body">
+      <p><code>MeasureText</code>, <code>MeasureTextEx</code> iterate codepoints and sum advance widths without touching the GPU. Useful for centering UI labels.</p>
+      <p><code>DrawTextCodepoints</code> skips UTF-8 decoding when you already have an int array — handy for internationalization tables.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Connection to rshapes</summary>
+    <div class="details-body">
+      <p>The default font atlas provides the white pixel region that <a href="rshapes.html">rshapes</a> uses for solid fills. This design choice unifies batching: shapes and text share one texture bind when drawn interleaved (same atlas for default font + shapes, or default 1×1 texture otherwise).</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L685-L702">InitWindow shapes/font wiring</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>External References</summary>
+    <div class="details-body">
+      <ul class="ref-list">
+        <li><a href="https://github.com/nothings/stb/blob/master/stb_truetype.h">stb_truetype</a> — font rasterization</li>
+        <li><a href="https://en.wikipedia.org/wiki/Typeface#Font_metrics">Font metrics</a> — advance, bearing, baseline concepts</li>
+        <li><a href="https://www.utf8.com/">UTF-8 overview</a></li>
+        <li><a href="https://www.raylib.com/examples.html">raylib examples — text category</a></li>
+      </ul>
+    </div>
+  </details>
+</main>
+
+</body>
+</html>

--- a/explainers/raylib-data-flow/rtextures.html
+++ b/explainers/raylib-data-flow/rtextures.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>raylib — rtextures (Images &amp; Textures)</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<nav class="site-nav">
+  <a class="brand" href="index.html">raylib Data Flow</a>
+  <a href="index.html">Overview</a>
+  <a href="rcore.html">rcore</a>
+  <a href="rlgl.html">rlgl</a>
+  <a href="rshapes.html">rshapes</a>
+  <a href="rtextures.html" class="active">rtextures</a>
+  <a href="rtext.html">rtext</a>
+  <a href="rmodels.html">rmodels</a>
+  <a href="raudio.html">raudio</a>
+</nav>
+
+<main>
+  <h1 class="page-title">rtextures — Images, Textures &amp; Render Targets</h1>
+  <p class="page-subtitle"><code>src/rtextures.c</code> handles CPU-side image data (<code>Image</code>), GPU textures (<code>Texture2D</code>), cubemaps, render textures (FBOs), and the <code>DrawTexture*</code> family.</p>
+
+  <details open>
+    <summary>Data Types</summary>
+    <div class="details-body">
+      <table>
+        <thead>
+          <tr><th>Type</th><th>Where it lives</th><th>Lifecycle</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>Image</code></td><td>CPU RAM (<code>image.data</code>)</td><td><code>LoadImage</code> → manipulate pixels → <code>UnloadImage</code></td></tr>
+          <tr><td><code>Texture2D</code></td><td>GPU (<code>texture.id</code> = OpenGL texture name)</td><td><code>LoadTextureFromImage</code> → draw → <code>UnloadTexture</code></td></tr>
+          <tr><td><code>RenderTexture2D</code></td><td>GPU FBO + color texture</td><td><code>LoadRenderTexture</code> → <code>BeginTextureMode</code> → <code>UnloadRenderTexture</code></td></tr>
+        </tbody>
+      </table>
+      <p>The typical load path decodes a file to CPU memory first, then uploads once to the GPU:</p>
+      <pre><code>Texture2D LoadTexture(const char *fileName)
+{
+    Image image = LoadImage(fileName);       // stb_image / custom decoders
+    Texture2D texture = LoadTextureFromImage(image);
+    UnloadImage(image);                      // free CPU copy
+    return texture;
+}</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rtextures.c#L4118-L4150">LoadTexture / LoadTextureFromImage</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>CPU → GPU Upload</summary>
+    <div class="details-body">
+      <pre><code>Texture2D LoadTextureFromImage(Image image)
+{
+    texture.id = rlLoadTexture(
+        image.data, image.width, image.height,
+        image.format, image.mipmaps);
+    texture.width = image.width;
+    texture.height = image.height;
+    return texture;
+}</code></pre>
+      <p><code>rlLoadTexture</code> (inside rlgl) calls <code>glGenTextures</code>, <code>glTexImage2D</code>, sets filtering/wrap, and optionally generates mipmaps. Compressed formats (DXT, ETC, ASTC) pass through when supported.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rtextures.c#L4135-L4150">LoadTextureFromImage</a>
+      <p>Image loading uses bundled <a href="https://github.com/nothings/stb">stb_image</a> and related decoders in <code>src/external/</code>.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Drawing Textures (2D Quad Path)</summary>
+    <div class="details-body">
+      <div class="flow-diagram">DrawTexture(texture, x, y, tint)
+  → DrawTextureEx → DrawTexturePro
+      │
+      ├─ compute destination quad (position, scale, rotation, origin)
+      ├─ map source Rectangle → UV coordinates
+      │
+      ├─ rlSetTexture(texture.id)
+      ├─ rlBegin(RL_QUADS)
+      │     per vertex: rlColor4ub(tint) rlTexCoord2f(u,v) rlVertex2f(x,y)
+      └─ rlEnd()</div>
+      <p><code>DrawTexturePro</code> is the general form used internally by text rendering and sprite sheets. It handles negative width/height flips and arbitrary sub-rectangles.</p>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rtextures.c#L4512-L4600">DrawTexturePro</a>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Render Textures (Off-Screen)</summary>
+    <div class="details-body">
+      <p><code>LoadRenderTexture</code> creates an FBO with a color texture attachment (and depth renderbuffer for 3D content). Drawing flow:</p>
+      <pre><code>RenderTexture2D target = LoadRenderTexture(800, 600);
+
+BeginTextureMode(target);    // rcore: bind FBO, set ortho viewport
+    ClearBackground(BLANK);
+    DrawCircle(400, 300, 100, RED);   // renders into target.texture
+EndTextureMode();            // rcore: restore default framebuffer
+
+DrawTexture(target.texture, 0, 0, WHITE);  // blit to screen</code></pre>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rtextures.c#L4260-L4320">LoadRenderTexture</a>
+      <a class="src-link" href="https://github.com/raysan5/raylib/blob/22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8/src/rcore.c#L996-L1040">BeginTextureMode / EndTextureMode</a>
+      <p>Note: OpenGL FBO origin is bottom-left; raylib's <code>LoadRenderTexture</code> flips the Y texture coordinate when drawing so it appears upright on screen.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Image Processing (CPU)</summary>
+    <div class="details-body">
+      <p>Before or instead of GPU upload, rtextures provides CPU pixel operations:</p>
+      <ul>
+        <li><code>ImageResize</code>, <code>ImageCrop</code>, <code>ImageFormat</code> — format conversion</li>
+        <li><code>ImageDrawPixel</code>, <code>ImageDrawRectangle</code> — CPU compositing</li>
+        <li><code>GenImageColor</code>, <code>GenImageGradient*</code> — procedural images</li>
+        <li><code>ExportImage</code> — write PNG via stb_image_write</li>
+      </ul>
+      <p>These operate on raw <code>image.data</code> bytes and never touch rlgl until you call <code>LoadTextureFromImage</code>.</p>
+    </div>
+  </details>
+
+  <details open>
+    <summary>Connections</summary>
+    <div class="details-body">
+      <ul>
+        <li><a href="rtext.html">rtext</a> builds font atlases as <code>Texture2D</code> and draws glyphs via <code>DrawTexturePro</code></li>
+        <li><a href="rmodels.html">rmodels</a> binds textures as material maps in 3D shaders (separate from 2D batch)</li>
+        <li><a href="rlgl.html">rlgl</a> owns <code>rlLoadTexture</code>, FBO helpers, and batch flushing on texture bind</li>
+        <li><a href="rcore.html">rcore</a> manages FBO viewport switching during <code>BeginTextureMode</code></li>
+      </ul>
+    </div>
+  </details>
+
+  <details open>
+    <summary>External References</summary>
+    <div class="details-body">
+      <ul class="ref-list">
+        <li><a href="https://www.khronos.org/opengl/wiki/Texture">OpenGL Wiki — Texture</a></li>
+        <li><a href="https://www.khronos.org/opengl/wiki/Framebuffer_Object">OpenGL Wiki — Framebuffer Object</a></li>
+        <li><a href="https://github.com/nothings/stb/blob/master/stb_image.h">stb_image</a> — default image decoder</li>
+        <li><a href="https://www.raylib.com/examples.html">raylib examples — textures category</a></li>
+      </ul>
+    </div>
+  </details>
+</main>
+
+</body>
+</html>

--- a/explainers/raylib-data-flow/styles.css
+++ b/explainers/raylib-data-flow/styles.css
@@ -1,0 +1,386 @@
+:root {
+  --bg: #f4f5f7;
+  --surface: #ffffff;
+  --surface-hover: #f0f2f5;
+  --text: #1a1a1a;
+  --muted: #555555;
+  --accent: #0066cc;
+  --accent-dark: #004a99;
+  --code-bg: #1e1e2e;
+  --code-fg: #e8e8e8;
+  --divider: #d8dce2;
+  --nav-bg: #1a2744;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+}
+
+a {
+  color: var(--accent);
+}
+
+a:hover {
+  color: var(--accent-dark);
+}
+
+/* Navigation */
+.site-nav {
+  background: var(--nav-bg);
+  padding: 14px 16px;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.site-nav .brand {
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 16px;
+  margin-right: 8px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.site-nav a {
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  font-size: 16px;
+  padding: 6px 12px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.site-nav a:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+}
+
+.site-nav a.active {
+  background: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+}
+
+/* Layout */
+main {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+}
+
+.page-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--accent-dark);
+  margin-bottom: 8px;
+}
+
+.page-subtitle {
+  color: var(--muted);
+  margin-bottom: 24px;
+}
+
+h2 {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--accent-dark);
+  margin: 28px 0 12px;
+}
+
+h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 20px 0 8px;
+}
+
+p {
+  margin-bottom: 12px;
+}
+
+p:last-child {
+  margin-bottom: 0;
+}
+
+ul, ol {
+  margin: 0 0 12px 20px;
+}
+
+li {
+  margin-bottom: 6px;
+}
+
+/* Expandable sections — open by default */
+details {
+  background: var(--surface);
+  border-radius: 6px;
+  margin-bottom: 16px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+details > summary {
+  list-style: none;
+  padding: 16px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  user-select: none;
+  background: var(--surface);
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
+}
+
+details > summary::before {
+  content: "▼";
+  font-size: 12px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+details:not([open]) > summary::before {
+  transform: rotate(-90deg);
+}
+
+details > summary:hover {
+  background: var(--surface-hover);
+}
+
+.details-body {
+  padding: 0 16px 16px;
+}
+
+/* Code */
+pre {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 16px;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre;
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", "Courier New", monospace;
+  margin: 12px 0;
+}
+
+code {
+  background: #e8eaed;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", "Courier New", monospace;
+  font-size: 14px;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  font-size: 14px;
+}
+
+.code-label {
+  font-size: 14px;
+  color: var(--muted);
+  font-family: monospace;
+  margin: 16px 0 4px;
+}
+
+/* Source links */
+.src-link {
+  display: inline-block;
+  font-family: monospace;
+  font-size: 14px;
+  color: var(--accent);
+  text-decoration: none;
+  margin: 4px 8px 4px 0;
+  padding: 4px 0;
+}
+
+.src-link:hover {
+  text-decoration: underline;
+}
+
+/* Flow diagram */
+.flow-diagram {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 16px;
+  border-radius: 6px;
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", "Courier New", monospace;
+  font-size: 14px;
+  line-height: 1.7;
+  white-space: pre;
+  overflow-x: auto;
+  margin: 16px 0;
+}
+
+/* Component cards */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+  margin: 16px 0;
+}
+
+.component-card {
+  background: var(--surface);
+  border-radius: 6px;
+  padding: 16px;
+  text-decoration: none;
+  color: var(--text);
+  display: block;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.component-card:hover {
+  background: var(--surface-hover);
+}
+
+.component-card h3 {
+  color: var(--accent);
+  margin: 0 0 8px;
+}
+
+.component-card .file {
+  font-family: monospace;
+  font-size: 14px;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
+.component-card p {
+  font-size: 16px;
+  color: var(--muted);
+  margin: 0;
+}
+
+/* Flow steps */
+.flow-steps {
+  margin: 16px 0;
+}
+
+.flow-step {
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  background: var(--surface);
+  border-radius: 6px;
+  margin-bottom: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.flow-step-num {
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 700;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 16px;
+}
+
+.flow-step-body {
+  flex: 1;
+}
+
+.flow-step-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.flow-step-desc {
+  color: var(--muted);
+}
+
+/* References */
+.ref-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ref-list li {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--divider);
+}
+
+.ref-list li:last-child {
+  border-bottom: none;
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+  font-size: 16px;
+}
+
+th {
+  background: var(--surface-hover);
+  padding: 12px 16px;
+  text-align: left;
+  font-weight: 600;
+}
+
+td {
+  padding: 12px 16px;
+  border-top: 1px solid var(--divider);
+}
+
+.tag {
+  display: inline-block;
+  background: var(--surface-hover);
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 14px;
+  margin: 2px 4px 2px 0;
+}
+
+.meta {
+  font-size: 14px;
+  color: var(--muted);
+  margin-bottom: 16px;
+}
+
+@media (max-width: 600px) {
+  .site-nav {
+    padding: 12px;
+  }
+
+  main {
+    padding: 16px 12px 32px;
+  }
+
+  .flow-step {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a mobile-friendly interactive documentation set under `explainers/raylib-data-flow/` tracing how [raylib](https://github.com/raysan5/raylib) moves data from the game loop to GPU pixels and audio output.

## Contents

- **Overview** (`index.html`) — end-to-end architecture, frame loop, 2D vs 3D paths
- **rcore** — window/platform init, `BeginDrawing`/`EndDrawing`, 3D mode, render targets
- **rlgl** — OpenGL abstraction, render batching, flush points
- **rshapes** — 2D primitives via immediate-mode vertices
- **rtextures** — image load, GPU upload, texture drawing, FBOs
- **rtext** — font atlas, UTF-8 text as textured quads
- **rmodels** — mesh loading, shaders, `DrawMesh` 3D path
- **raudio** — miniaudio device callback and mixing

## Features

- `<details open>` sections expanded by default; collapsible for navigation
- GitHub permalinks to source at commit `22509ab`
- External references (OpenGL, GLFW, miniaudio, LearnOpenGL, etc.)
- Shared `styles.css` with consistent padding, 16px base font, `white-space: pre` on code blocks
- No gradients, glow, or thin colored borders

Source analyzed from a shallow clone of raysan5/raylib @ `22509ab2d4b1e1b9b8fb874c05b08ae9a26d44d8`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2cd421a-f261-4903-ac02-47a9d257bb78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2cd421a-f261-4903-ac02-47a9d257bb78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

