### PR TITLE
Add interactive raylib data-flow explainer

### DIFF
--- a/explainers/raylib-data-flow/assets/site.js
+++ b/explainers/raylib-data-flow/assets/site.js
@@ -1,0 +1,420 @@
+(function () {
+  function all(selector, root) {
+    return Array.prototype.slice.call((root || document).querySelectorAll(selector));
+  }
+
+  function setDetails(open) {
+    all("details").forEach(function (detail) {
+      detail.open = open;
+    });
+  }
+
+  function setupControls() {
+    var expand = document.querySelector("[data-expand-all]");
+    var collapse = document.querySelector("[data-collapse-all]");
+    if (expand) {
+      expand.addEventListener("click", function () {
+        setDetails(true);
+      });
+    }
+    if (collapse) {
+      collapse.addEventListener("click", function () {
+        setDetails(false);
+      });
+    }
+  }
+
+  function setupSearch() {
+    var input = document.querySelector("[data-search]");
+    var count = document.querySelector("[data-search-count]");
+    if (!input) return;
+
+    var searchable = all(".searchable");
+    function filter() {
+      var query = input.value.trim().toLowerCase();
+      var visible = 0;
+      searchable.forEach(function (item) {
+        var matches = !query || item.textContent.toLowerCase().indexOf(query) !== -1;
+        item.classList.toggle("hidden", !matches);
+        if (matches) visible += 1;
+      });
+      if (count) {
+        count.textContent = query ? visible + " matching blocks" : searchable.length + " blocks";
+      }
+    }
+    input.addEventListener("input", filter);
+    filter();
+  }
+
+  function setupFlowFocus() {
+    all("[data-flow-step]").forEach(function (step) {
+      step.addEventListener("click", function () {
+        var key = step.getAttribute("data-flow-step");
+        all("[data-flow-step]").forEach(function (item) {
+          item.classList.toggle("is-active", item.getAttribute("data-flow-step") === key);
+        });
+        all("[data-flow-target]").forEach(function (item) {
+          var active = item.getAttribute("data-flow-target") === key;
+          item.classList.toggle("is-active", active);
+          if (active && item.tagName === "DETAILS") item.open = true;
+        });
+        var target = document.querySelector('[data-flow-target="' + key + '"]');
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        }
+      });
+    });
+  }
+
+  var archData = {
+    app: {
+      title: "Your game (main)",
+      body: "You write main(), own the loop, and call InitWindow / BeginDrawing / EndDrawing. raylib does not embed a game loop or scene graph."
+    },
+    rcore: {
+      title: "rcore.c",
+      body: "Window lifecycle, CORE global state (input, timing, window flags), file I/O, InitWindow/CloseWindow, BeginDrawing/EndDrawing. Platform code is #include'd into this file."
+    },
+    rlgl: {
+      title: "rlgl.h",
+      body: "OpenGL abstraction layer. Immediate-mode rlBegin/rlVertex/rlEnd backed by VBO batching on GL 3.3 and ES2. Owns default shader, 1×1 white texture, and render batch."
+    },
+    rshapes: {
+      title: "rshapes.c",
+      body: "DrawRectangle, DrawCircle, 2D collisions. All shapes emit textured quads into the rlgl batch (even solid colors)."
+    },
+    rtextures: {
+      title: "rtextures.c",
+      body: "Image in RAM (stb_image, qoi), Texture2D in VRAM (rlLoadTexture), DrawTexturePro, render textures."
+    },
+    rtext: {
+      title: "rtext.c",
+      body: "Font loading (TTF/FNT), DrawText. Each glyph is a DrawTexturePro call into the same batch as shapes."
+    },
+    rmodels: {
+      title: "rmodels.c",
+      body: "LoadModel (OBJ, glTF, IQM…), UploadMesh to VAO/VBO, DrawMesh with shaders. 3D bypasses the 2D batch."
+    },
+    raudio: {
+      title: "raudio.c",
+      body: "miniaudio device + linked-list AudioBuffer mixing in OnSendAudioDataToDevice. Opt-in via InitAudioDevice."
+    },
+    platform: {
+      title: "platforms/rcore_*.c",
+      body: "GLFW (default desktop), SDL, RGFW, Win32, Web, DRM, Android, Memory. Selected at compile time via PLATFORM_* defines."
+    }
+  };
+
+  function setupArchMap() {
+    var map = document.querySelector("[data-arch-map]");
+    if (!map) return;
+
+    var detailTitle = document.querySelector("[data-arch-title]");
+    var detailBody = document.querySelector("[data-arch-body]");
+
+    all("[data-arch-node]", map).forEach(function (node) {
+      node.addEventListener("click", function () {
+        var key = node.getAttribute("data-arch-node");
+        all("[data-arch-node]", map).forEach(function (n) {
+          n.classList.toggle("is-active", n.getAttribute("data-arch-node") === key);
+        });
+        var info = archData[key];
+        if (info && detailTitle && detailBody) {
+          detailTitle.textContent = info.title;
+          detailBody.textContent = info.body;
+        }
+      });
+    });
+
+    var first = map.querySelector("[data-arch-node]");
+    if (first) first.click();
+  }
+
+  function setupFrameDemo() {
+    var canvas = document.querySelector("[data-frame-demo]");
+    if (!canvas) return;
+
+    var ctx = canvas.getContext("2d");
+    var step = 0;
+    var frame = 0;
+    var batchVerts = 0;
+    var running = false;
+    var animId = null;
+
+    var steps = [
+      { label: "Poll input", color: "#1a5c8a" },
+      { label: "BeginDrawing", color: "#0e8a3e" },
+      { label: "Draw calls", color: "#6a8a0e" },
+      { label: "Flush batch", color: "#8a5c0e" },
+      { label: "Swap buffers", color: "#8a3a0e" },
+      { label: "Wait FPS", color: "#5c3a8a" }
+    ];
+
+    function resize() {
+      var wrap = canvas.parentElement;
+      var w = wrap.clientWidth;
+      var h = wrap.clientHeight;
+      canvas.width = w * (window.devicePixelRatio || 1);
+      canvas.height = h * (window.devicePixelRatio || 1);
+      ctx.setTransform(window.devicePixelRatio || 1, 0, 0, window.devicePixelRatio || 1, 0, 0);
+    }
+
+    function drawScene() {
+      var w = canvas.width / (window.devicePixelRatio || 1);
+      var h = canvas.height / (window.devicePixelRatio || 1);
+      ctx.fillStyle = "#245324";
+      ctx.fillRect(0, 0, w, h);
+
+      ctx.fillStyle = "rgba(0,0,0,0.35)";
+      ctx.fillRect(8, 8, w - 16, h - 16);
+
+      var cx = w / 2;
+      var cy = h / 2 + 10;
+
+      if (step >= 2) {
+        ctx.fillStyle = "#0e8a3e";
+        ctx.fillRect(cx - 70, cy - 30, 140, 60);
+        batchVerts += 4;
+      }
+      if (step >= 2) {
+        ctx.fillStyle = "#c8e6c9";
+        ctx.font = "14px sans-serif";
+        ctx.fillText("DrawText + shapes", cx - 55, cy + 5);
+        batchVerts += 4;
+      }
+      if (step >= 3) {
+        ctx.strokeStyle = "#ffd54f";
+        ctx.lineWidth = 2;
+        ctx.strokeRect(cx - 72, cy - 32, 144, 64);
+      }
+
+      var barY = 24;
+      steps.forEach(function (s, i) {
+        var active = i === step;
+        var done = i < step;
+        ctx.fillStyle = done ? s.color : active ? s.color : "#444";
+        ctx.globalAlpha = active ? 1 : done ? 0.85 : 0.35;
+        ctx.fillRect(16, barY + i * 22, w - 32, 18);
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = "#fff";
+        ctx.font = "11px sans-serif";
+        ctx.fillText(s.label, 22, barY + i * 22 + 13);
+      });
+    }
+
+    function updateStats() {
+      var elFrame = document.querySelector("[data-stat-frame]");
+      var elStep = document.querySelector("[data-stat-step]");
+      var elVerts = document.querySelector("[data-stat-verts]");
+      if (elFrame) elFrame.textContent = String(frame);
+      if (elStep) elStep.textContent = steps[step].label;
+      if (elVerts) elVerts.textContent = step >= 3 ? "0 (flushed)" : String(batchVerts);
+    }
+
+    function tick() {
+      if (!running) return;
+      step = (step + 1) % steps.length;
+      if (step === 0) {
+        frame += 1;
+        batchVerts = 0;
+      }
+      if (step === 2) batchVerts = 8;
+      drawScene();
+      updateStats();
+      animId = window.setTimeout(tick, 900);
+    }
+
+    var playBtn = document.querySelector("[data-demo-play]");
+    var stepBtn = document.querySelector("[data-demo-step]");
+    var resetBtn = document.querySelector("[data-demo-reset]");
+
+    if (playBtn) {
+      playBtn.addEventListener("click", function () {
+        running = !running;
+        playBtn.textContent = running ? "Pause" : "Play loop";
+        if (running) tick();
+        else if (animId) window.clearTimeout(animId);
+      });
+    }
+    if (stepBtn) {
+      stepBtn.addEventListener("click", function () {
+        running = false;
+        if (animId) window.clearTimeout(animId);
+        if (playBtn) playBtn.textContent = "Play loop";
+        step = (step + 1) % steps.length;
+        if (step === 0) { frame += 1; batchVerts = 0; }
+        if (step === 2) batchVerts = 8;
+        drawScene();
+        updateStats();
+      });
+    }
+    if (resetBtn) {
+      resetBtn.addEventListener("click", function () {
+        running = false;
+        if (animId) window.clearTimeout(animId);
+        if (playBtn) playBtn.textContent = "Play loop";
+        step = 0;
+        frame = 0;
+        batchVerts = 0;
+        drawScene();
+        updateStats();
+      });
+    }
+
+    window.addEventListener("resize", function () {
+      resize();
+      drawScene();
+    });
+    resize();
+    drawScene();
+    updateStats();
+  }
+
+  var platformInfo = {
+    glfw: {
+      define: "PLATFORM_DESKTOP_GLFW",
+      file: "rcore_desktop_glfw.c",
+      notes: "Default desktop backend. Vendored GLFW in rglfw.c or system libglfw. glfwPollEvents in EndDrawing."
+    },
+    sdl: {
+      define: "PLATFORM_DESKTOP_SDL",
+      file: "rcore_desktop_sdl.c",
+      notes: "SDL2/SDL3 window and input. CMake PLATFORM=SDL or zig build -Dplatform=sdl2."
+    },
+    rgfw: {
+      define: "PLATFORM_DESKTOP_RGFW",
+      file: "rcore_desktop_rgfw.c",
+      notes: "Lightweight RGFW windowing. Also used for PLATFORM_WEB_RGFW on WebAssembly."
+    },
+    drm: {
+      define: "PLATFORM_DRM",
+      file: "rcore_drm.c",
+      notes: "Linux DRM/KMS for Raspberry Pi and embedded. Often paired with GLES2."
+    },
+    web: {
+      define: "PLATFORM_WEB",
+      file: "rcore_web.c",
+      notes: "Emscripten + GLFW. Built with emcmake cmake -DPLATFORM=Web."
+    },
+    android: {
+      define: "PLATFORM_ANDROID",
+      file: "rcore_android.c",
+      notes: "NDK native activity. fopen wrapped for APK asset loading."
+    },
+    memory: {
+      define: "PLATFORM_MEMORY",
+      file: "rcore_memory.c",
+      notes: "Headless software renderer via rlsw. No OS window."
+    }
+  };
+
+  function setupPlatformPicker() {
+    var grid = document.querySelector("[data-platform-grid]");
+    if (!grid) return;
+
+    var defineEl = document.querySelector("[data-platform-define]");
+    var fileEl = document.querySelector("[data-platform-file]");
+    var notesEl = document.querySelector("[data-platform-notes]");
+
+    all("[data-platform]", grid).forEach(function (card) {
+      card.addEventListener("click", function () {
+        var key = card.getAttribute("data-platform");
+        all("[data-platform]", grid).forEach(function (c) {
+          c.classList.toggle("is-active", c.getAttribute("data-platform") === key);
+        });
+        var info = platformInfo[key];
+        if (info) {
+          if (defineEl) defineEl.textContent = info.define;
+          if (fileEl) fileEl.textContent = info.file;
+          if (notesEl) notesEl.textContent = info.notes;
+        }
+      });
+    });
+
+    var first = grid.querySelector("[data-platform]");
+    if (first) first.click();
+  }
+
+  function setupBatchDemo() {
+    var canvas = document.querySelector("[data-batch-demo]");
+    if (!canvas) return;
+
+    var ctx = canvas.getContext("2d");
+    var rects = [];
+    var flushed = false;
+    var texSwaps = 0;
+
+    function resize() {
+      var wrap = canvas.parentElement;
+      canvas.width = wrap.clientWidth * (window.devicePixelRatio || 1);
+      canvas.height = wrap.clientHeight * (window.devicePixelRatio || 1);
+      ctx.setTransform(window.devicePixelRatio || 1, 0, 0, window.devicePixelRatio || 1, 0, 0);
+    }
+
+    function draw() {
+      var w = canvas.width / (window.devicePixelRatio || 1);
+      var h = canvas.height / (window.devicePixelRatio || 1);
+      ctx.fillStyle = "#1a1f1a";
+      ctx.fillRect(0, 0, w, h);
+
+      if (flushed) {
+        ctx.fillStyle = "#0e8a3e";
+        ctx.font = "13px sans-serif";
+        ctx.fillText("Batch flushed → GPU draw call", 12, 22);
+        flushed = false;
+        rects = [];
+      }
+
+      rects.forEach(function (r) {
+        ctx.fillStyle = r.color;
+        ctx.fillRect(r.x, r.y, r.w, r.h);
+      });
+
+      var stat = document.querySelector("[data-batch-count]");
+      if (stat) stat.textContent = String(rects.length * 4) + " verts";
+    }
+
+    document.querySelector("[data-batch-add]")?.addEventListener("click", function () {
+      var colors = ["#0e8a3e", "#1a5c8a", "#8a5c0e", "#8a0e5c"];
+      var w = canvas.width / (window.devicePixelRatio || 1);
+      var h = canvas.height / (window.devicePixelRatio || 1);
+      rects.push({
+        x: 20 + Math.random() * (w - 80),
+        y: 30 + Math.random() * (h - 60),
+        w: 40 + Math.random() * 50,
+        h: 24 + Math.random() * 30,
+        color: colors[rects.length % colors.length]
+      });
+      draw();
+    });
+
+    document.querySelector("[data-batch-flush]")?.addEventListener("click", function () {
+      flushed = true;
+      draw();
+      var dc = document.querySelector("[data-batch-dc]");
+      if (dc) dc.textContent = String(parseInt(dc.textContent, 10) + 1);
+    });
+
+    document.querySelector("[data-batch-texture]")?.addEventListener("click", function () {
+      texSwaps += 1;
+      flushed = true;
+      var ts = document.querySelector("[data-batch-tex]");
+      if (ts) ts.textContent = String(texSwaps);
+      draw();
+    });
+
+    window.addEventListener("resize", function () { resize(); draw(); });
+    resize();
+    draw();
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    setupControls();
+    setupSearch();
+    setupFlowFocus();
+    setupArchMap();
+    setupFrameDemo();
+    setupPlatformPicker();
+    setupBatchDemo();
+  });
+})();

--- a/explainers/raylib-data-flow/assets/styles.css
+++ b/explainers/raylib-data-flow/assets/styles.css
@@ -1,0 +1,581 @@
+:root {
+  --bg: #f4f6f2;
+  --panel: #ffffff;
+  --panel-2: #e8ede4;
+  --ink: #141814;
+  --muted: #4a524a;
+  --line: #c8d0c4;
+  --line-strong: #8a9688;
+  --accent: #0e8a3e;
+  --accent-2: #1a5c8a;
+  --accent-soft: #d4eddc;
+  --code-bg: #1a1f1a;
+  --code-ink: #eef2ea;
+  --warn: #8b4d12;
+  --radius: 8px;
+  --space-1: 8px;
+  --space-2: 12px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 32px;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--ink);
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+a {
+  color: var(--accent-2);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+  background: var(--panel-2);
+  border-right: 2px solid var(--line);
+  padding: var(--space-4);
+}
+
+.brand {
+  display: grid;
+  gap: var(--space-1);
+  margin-bottom: var(--space-4);
+}
+
+.brand strong {
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.brand span,
+.meta,
+.small {
+  color: var(--muted);
+  font-size: 15px;
+}
+
+.nav {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.nav a {
+  display: block;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.nav a[aria-current="page"],
+.nav a:hover,
+.nav a:focus {
+  background: var(--panel);
+  outline: 2px solid var(--line-strong);
+  outline-offset: -2px;
+}
+
+.content {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--space-5);
+}
+
+.topbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-4);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+button,
+input[type="search"],
+select {
+  min-height: 44px;
+  border: 2px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--panel);
+  color: var(--ink);
+  font: inherit;
+  padding: 9px 12px;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:hover,
+button:focus,
+input[type="search"]:focus,
+select:focus {
+  outline: 3px solid #a8c4a8;
+  outline-offset: 2px;
+}
+
+input[type="search"] {
+  width: min(100%, 360px);
+}
+
+h1, h2, h3 {
+  line-height: 1.2;
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(24px, 5vw, 28px);
+  margin-bottom: var(--space-3);
+}
+
+h2 {
+  font-size: 22px;
+}
+
+h3 {
+  font-size: 18px;
+}
+
+p {
+  margin: 0 0 var(--space-3);
+}
+
+.lead {
+  font-size: 18px;
+  max-width: 78ch;
+}
+
+.section {
+  margin: 0 0 var(--space-5);
+}
+
+.panel,
+details,
+.flow-step,
+.table-wrap,
+.arch-node,
+.demo-panel {
+  background: var(--panel);
+  border: 2px solid var(--line);
+  border-radius: var(--radius);
+}
+
+.panel {
+  padding: var(--space-4);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.grid.three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.stack {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.flow {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.flow-step {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.flow-step.is-active,
+.flow-step:hover,
+.flow-step:focus {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.step-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  border-radius: 999px;
+  background: var(--panel-2);
+  color: var(--ink);
+  padding: 3px 10px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.badge-mandatory {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+details {
+  padding: 0;
+  overflow: hidden;
+}
+
+details.is-active {
+  border-color: var(--accent);
+}
+
+summary {
+  cursor: pointer;
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  font-weight: 700;
+}
+
+summary::marker {
+  color: var(--accent);
+}
+
+.details-body {
+  border-top: 2px solid var(--line);
+  padding: var(--space-4);
+}
+
+pre, code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+pre {
+  margin: var(--space-3) 0 0;
+  overflow-x: auto;
+  white-space: pre;
+  background: var(--code-bg);
+  color: var(--code-ink);
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  font-size: 14px;
+  line-height: 1.55;
+  -webkit-overflow-scrolling: touch;
+}
+
+code {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+p code, li code, td code, summary code {
+  background: var(--panel-2);
+  color: var(--ink);
+  border-radius: 4px;
+  padding: 1px 4px;
+  white-space: nowrap;
+}
+
+ul, ol {
+  margin: 0;
+  padding-left: 22px;
+}
+
+li + li {
+  margin-top: var(--space-1);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: var(--space-2);
+  border-bottom: 2px solid var(--line);
+}
+
+th {
+  background: var(--panel-2);
+}
+
+.table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.callout {
+  border-left: 6px solid var(--accent);
+  padding: var(--space-3);
+  background: var(--accent-soft);
+  border-radius: var(--radius);
+}
+
+.callout-warn {
+  border-left-color: var(--warn);
+  background: #f5ebe0;
+}
+
+.coderef {
+  margin-top: var(--space-3);
+  font-size: 15px;
+}
+
+.coderef a {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  word-break: break-all;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.footer {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 2px solid var(--line);
+  color: var(--muted);
+}
+
+/* Interactive architecture map */
+.arch-map {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.arch-row {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.arch-node {
+  padding: var(--space-3);
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  min-height: 72px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+}
+
+.arch-node strong {
+  font-size: 15px;
+  color: var(--accent-2);
+}
+
+.arch-node span {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.arch-node.is-active,
+.arch-node:hover,
+.arch-node:focus {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.arch-detail {
+  padding: var(--space-4);
+  min-height: 120px;
+}
+
+.arch-detail h3 {
+  margin-bottom: var(--space-2);
+  color: var(--accent);
+}
+
+/* Canvas demo */
+.demo-panel {
+  padding: var(--space-4);
+}
+
+.demo-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.demo-canvas-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  aspect-ratio: 16 / 10;
+  background: #245324;
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 2px solid var(--line-strong);
+}
+
+.demo-canvas-wrap canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.demo-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.stat-box {
+  background: var(--panel-2);
+  border-radius: var(--radius);
+  padding: var(--space-2);
+  text-align: center;
+}
+
+.stat-box strong {
+  display: block;
+  font-size: 22px;
+  color: var(--accent);
+}
+
+.stat-box span {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+/* Platform picker */
+.platform-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--space-2);
+}
+
+.platform-card {
+  padding: var(--space-3);
+  border: 2px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  min-height: 44px;
+}
+
+.platform-card.is-active,
+.platform-card:hover,
+.platform-card:focus {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.platform-card code {
+  display: block;
+  margin-top: 6px;
+  font-size: 12px;
+  white-space: normal;
+}
+
+@media (max-width: 860px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    border-right: 0;
+    border-bottom: 2px solid var(--line);
+    padding: var(--space-3);
+  }
+
+  .nav {
+    display: flex;
+    flex-wrap: wrap;
+    overflow-x: auto;
+    padding-bottom: var(--space-1);
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .nav a {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .content {
+    padding: var(--space-4) var(--space-3);
+  }
+
+  .grid,
+  .grid.three {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    align-items: stretch;
+  }
+
+  .controls,
+  input[type="search"],
+  button,
+  select {
+    width: 100%;
+  }
+
+  .demo-toolbar button {
+    flex: 1 1 auto;
+  }
+}

--- a/explainers/raylib-data-flow/components/audio-system.html
+++ b/explainers/raylib-data-flow/components/audio-system.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Audio system — raylib Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>raylib Data Flow</strong>
+        <span>raysan5/raylib @ <code>22509ab</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="frame-lifecycle.html">Frame lifecycle</a>
+        <a href="rlgl-batching.html">rlgl &amp; batching</a>
+        <a href="platform-backends.html">Platform backends</a>
+        <a href="textures-and-images.html">Textures &amp; images</a>
+        <a href="models-and-3d.html">Models &amp; 3D</a>
+        <a href="audio-system.html" aria-current="page">Audio system</a>
+        <a href="modules-and-build.html">Modules &amp; build</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Audio system: miniaudio mixing</h1>
+          <p class="lead"><code>raudio.c</code> is the most isolated raylib module — no OpenGL. Audio is opt-in: call <code>InitAudioDevice()</code> separately from <code>InitWindow()</code>. Playback uses miniaudio's device callback to mix linked <code>AudioBuffer</code> nodes.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>Startup and load</h2>
+        <pre><code>InitAudioDevice()
+  ├─ ma_context_init()
+  ├─ ma_device_init(..., OnSendAudioDataToDevice)
+  └─ ma_device_start()
+
+Sound s = LoadSound("hit.wav")
+  ├─ LoadWave() → dr_wav / stb_vorbis / dr_mp3 / …
+  ├─ LoadSoundFromWave()
+  │     ma_convert_frames() → device format (float32 stereo)
+  │     LoadAudioBuffer() → linked list AUDIO.Buffer
+  └─ UnloadWave()
+
+PlaySound(s) → PlayAudioBuffer()</code></pre>
+        <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/raudio.c#L465-L520">raudio.c — InitAudioDevice</a></p>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Mixing callback (each audio buffer period)</h2>
+        <pre><code>OnSendAudioDataToDevice(pDevice, pFramesOut, ..., frameCount)
+  ├─ memset output to silence
+  ├─ ma_mutex_lock(AUDIO.System.lock)
+  ├─ for each AudioBuffer in linked list:
+  │     if playing && !paused:
+  │         read frames (static sound or stream)
+  │         MixAudioFrames(out, in, volume, pitch, pan)
+  └─ ma_mutex_unlock()</code></pre>
+        <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/raudio.c#L2560">raudio.c L2560+ — OnSendAudioDataToDevice</a></p>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>Sound vs Music vs AudioStream</summary>
+          <div class="details-body">
+            <ul>
+              <li><strong>Sound</strong> — fully decoded static buffer in RAM, low latency replay</li>
+              <li><strong>Music</strong> — streaming decoder (OGG, MP3, XM, MOD) refills buffer over time</li>
+              <li><strong>AudioStream</strong> — raw PCM you push with <code>UpdateAudioStream</code></li>
+            </ul>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Format conversion at load time</summary>
+          <div class="details-body">
+            <p>Sounds are converted to the device format at load (<code>ma_convert_frames</code>) rather than during mixing — simpler mixer, more memory for 8/16-bit sources.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/raudio.c#L945-L975">raudio.c — LoadSoundFromWave</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Threading model</summary>
+          <div class="details-body">
+            <p>Mixing runs on miniaudio's audio thread. A mutex protects the buffer list — documented as not real-time safe but acceptable for games. Main thread calls <code>PlaySound</code>, <code>StopSound</code>, etc.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Compile without audio</summary>
+          <div class="details-body">
+            <p><code>-DSUPPORT_MODULE_RAUDIO=0</code> or CMake <code>-DCUSTOMIZE_BUILD=ON -DSUPPORT_MODULE_RAUDIO=OFF</code> removes <code>raudio.c</code> from the build entirely.</p>
+          </div>
+        </details>
+      </section>
+
+      <footer class="footer">
+        <p><a href="models-and-3d.html">← Models &amp; 3D</a> · <a href="modules-and-build.html">Modules &amp; build →</a></p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/raylib-data-flow/components/frame-lifecycle.html
+++ b/explainers/raylib-data-flow/components/frame-lifecycle.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Frame lifecycle — raylib Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>raylib Data Flow</strong>
+        <span>raysan5/raylib @ <code>22509ab</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="frame-lifecycle.html" aria-current="page">Frame lifecycle</a>
+        <a href="rlgl-batching.html">rlgl &amp; batching</a>
+        <a href="platform-backends.html">Platform backends</a>
+        <a href="textures-and-images.html">Textures &amp; images</a>
+        <a href="models-and-3d.html">Models &amp; 3D</a>
+        <a href="audio-system.html">Audio system</a>
+        <a href="modules-and-build.html">Modules &amp; build</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Frame lifecycle: InitWindow through CloseWindow</h1>
+          <p class="lead">raylib does not provide <code>main()</code> or a game loop. The contract is: initialize once, loop until close, shut down. This page traces that contract through <code>CORE</code> state and the functions every example uses.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>Minimal program shape</h2>
+        <pre><code>#include "raylib.h"
+
+int main(void)
+{
+    InitWindow(800, 450, "my game");
+    SetTargetFPS(60);
+
+    while (!WindowShouldClose())
+    {
+        // update logic here
+        BeginDrawing();
+        ClearBackground(RAYWHITE);
+        DrawText("Hello", 190, 200, 20, DARKGRAY);
+        EndDrawing();
+    }
+
+    CloseWindow();
+    return 0;
+}</code></pre>
+        <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/examples/core/core_basic_window.c">examples/core/core_basic_window.c</a></p>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>InitWindow sequence</h2>
+        <pre><code>InitWindow(w, h, title)
+  ├─ init CORE.Window, CORE.Input (exit key = ESC)
+  ├─ InitPlatform()          // GLFW: glfwInit, create window, GL context
+  ├─ rlglInit(renderW, renderH)   // default texture, shader, batch
+  ├─ SetupViewport(...)
+  ├─ LoadFontDefault()       // if SUPPORT_MODULE_RTEXT
+  ├─ SetShapesTexture(...)   // share font atlas with rshapes batching
+  └─ SetRandomSeed(time(NULL))</code></pre>
+        <div class="callout callout-warn">
+          <p><strong>Failure mode:</strong> If <code>InitPlatform()</code> returns non-zero, <code>InitWindow</code> logs a warning and returns early. <code>IsWindowReady()</code> stays false and <code>WindowShouldClose()</code> returns true immediately.</p>
+        </div>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>BeginDrawing — start of draw phase</summary>
+          <div class="details-body">
+            <p>Updates <code>CORE.Time.current</code> and <code>CORE.Time.update</code> (seconds since last <code>BeginDrawing</code>). Resets modelview with <code>rlLoadIdentity()</code> and applies <code>CORE.Window.screenScale</code> for Retina/HiDPI.</p>
+            <p>Does <em>not</em> clear the framebuffer — you must call <code>ClearBackground</code> or draw over previous contents.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L858-L872">rcore.c L858–872</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>EndDrawing — flush, present, poll</summary>
+          <div class="details-body">
+            <ol>
+              <li><code>rlDrawRenderBatchActive()</code> — flush 2D batch to GPU</li>
+              <li><code>SwapScreenBuffer()</code> — platform (e.g. <code>glfwSwapBuffers</code>)</li>
+              <li>Measure draw time; <code>WaitTime()</code> if under target frame time</li>
+              <li><code>PollInputEvents()</code> — update keyboard/mouse/gamepad state</li>
+              <li>Increment <code>CORE.Time.frameCounter</code></li>
+            </ol>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L875-L917">rcore.c L875–917</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Render modes that flush the batch</summary>
+          <div class="details-body">
+            <p>Switching render context always calls <code>rlDrawRenderBatchActive()</code> first:</p>
+            <ul>
+              <li><code>BeginMode2D</code> / <code>EndMode2D</code> — 2D camera matrix</li>
+              <li><code>BeginMode3D</code> / <code>EndMode3D</code> — perspective + depth test</li>
+              <li><code>BeginTextureMode</code> / <code>EndTextureMode</code> — render to FBO</li>
+              <li><code>BeginShaderMode</code> — custom shader</li>
+            </ul>
+            <p>Mixing 2D and 3D in one frame requires these pairs — otherwise batch state and GL state desync.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>WindowShouldClose and ESC</summary>
+          <div class="details-body">
+            <p>On GLFW, <code>PollInputEvents</code> sets <code>CORE.Window.shouldClose</code> from <code>glfwWindowShouldClose</code>, then resets the GLFW flag so closing is driven by raylib's state. <code>CORE.Input.Keyboard.exitKey</code> defaults to <code>KEY_ESCAPE</code>.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/platforms/rcore_desktop_glfw.c#L1407-L1410">rcore_desktop_glfw.c L1407–1410</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>CloseWindow teardown</summary>
+          <div class="details-body">
+            <p><code>UnloadFontDefault()</code> → <code>rlglClose()</code> → <code>ClosePlatform()</code> (e.g. <code>glfwTerminate</code>). Sets <code>CORE.Window.ready = false</code>.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L723-L738">rcore.c L723–738</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>CORE global state</summary>
+          <div class="details-body">
+            <p><code>CoreData CORE</code> holds nested structs:</p>
+            <ul>
+              <li><code>Window</code> — dimensions, flags, shouldClose, screenScale matrix</li>
+              <li><code>Input.Keyboard/Mouse/Touch/Gamepad</code> — current + previous state arrays</li>
+              <li><code>Time</code> — current, update, draw, frame, target FPS interval</li>
+            </ul>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L296-L399">rcore.c L296–399 — CoreData</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section demo-panel searchable">
+        <h2>Frame loop simulator</h2>
+        <p>Same demo as the overview — step through poll → draw → flush → swap.</p>
+        <div class="demo-toolbar">
+          <button type="button" data-demo-play>Play loop</button>
+          <button type="button" data-demo-step>Step</button>
+          <button type="button" data-demo-reset>Reset</button>
+        </div>
+        <div class="demo-canvas-wrap">
+          <canvas data-frame-demo aria-label="Frame loop animation"></canvas>
+        </div>
+        <div class="demo-stats">
+          <div class="stat-box"><strong data-stat-frame>0</strong><span>Frame #</span></div>
+          <div class="stat-box"><strong data-stat-step>Poll input</strong><span>Phase</span></div>
+          <div class="stat-box"><strong data-stat-verts>0</strong><span>Batch verts</span></div>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p><a href="../index.html">← Overview</a> · <a href="rlgl-batching.html">rlgl &amp; batching →</a></p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/raylib-data-flow/components/models-and-3d.html
+++ b/explainers/raylib-data-flow/components/models-and-3d.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Models &amp; 3D — raylib Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>raylib Data Flow</strong>
+        <span>raysan5/raylib @ <code>22509ab</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="frame-lifecycle.html">Frame lifecycle</a>
+        <a href="rlgl-batching.html">rlgl &amp; batching</a>
+        <a href="platform-backends.html">Platform backends</a>
+        <a href="textures-and-images.html">Textures &amp; images</a>
+        <a href="models-and-3d.html" aria-current="page">Models &amp; 3D</a>
+        <a href="audio-system.html">Audio system</a>
+        <a href="modules-and-build.html">Modules &amp; build</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Models and 3D rendering</h1>
+          <p class="lead"><code>rmodels.c</code> loads geometry into <code>Mesh</code> CPU arrays, uploads to VAO/VBO via <code>UploadMesh</code>, and draws with per-material shaders through <code>DrawMesh</code>. The 2D render batch is flushed before entering 3D mode.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>LoadModel flow</h2>
+        <pre><code>LoadModel("scene.gltf")
+  ├─ extension dispatch:
+  │     .obj  → LoadOBJ (tinyobj_loader_c)
+  │     .gltf → LoadGLTF (cgltf)
+  │     .iqm  → LoadIQM
+  │     .m3d  → LoadM3D
+  │
+  ├─ model.transform = MatrixIdentity()
+  ├─ for each mesh: UploadMesh(&mesh, false)  → GPU VAO/VBO
+  └─ if no materials: create default white material + default shader</code></pre>
+        <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rmodels.c#L1102-L1137">rmodels.c L1102–1137 — LoadModel</a></p>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Draw path in one frame</h2>
+        <pre><code>BeginMode3D(camera)          // flush batch, set projection + view, depth on
+DrawModel(model, pos, scale, tint)
+  └─ DrawModelEx
+       ├─ build scale × rotate × translate matrix
+       ├─ model.transform = model.transform × matTransform  ⚠ mutates model
+       └─ for each mesh:
+            tint material diffuse color
+            upload bone matrices if skeletal
+            DrawMesh(mesh, material, model.transform)
+EndMode3D()                  // flush, restore 2D ortho, depth off</code></pre>
+        <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rmodels.c#L3922-L3963">rmodels.c — DrawModelEx</a></p>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>DrawMesh (GL 3.3 / ES2)</summary>
+          <div class="details-body">
+            <ol>
+              <li><code>rlEnableShader(material.shader.id)</code></li>
+              <li>Set uniforms: <code>colDiffuse</code>, <code>matModel</code>, <code>matView</code>, <code>matProjection</code>, <code>matNormal</code></li>
+              <li>Bind material texture maps to texture slots 0…N</li>
+              <li>Enable VAO / bind VBOs per attribute location</li>
+              <li><code>rlDrawVertexArrayElements</code> or indexed draw</li>
+            </ol>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rmodels.c#L1478">rmodels.c L1478+ — DrawMesh</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>BeginMode3D matrix setup</summary>
+          <div class="details-body">
+            <p>Pushes projection matrix, sets frustum or ortho from <code>camera.fovy</code> and aspect ratio (<code>currentFbo.width/height</code>), loads view matrix from <code>MatrixLookAt</code>, enables depth test.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L941-L993">rcore.c — BeginMode3D / EndMode3D</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Model data structures</summary>
+          <div class="details-body">
+            <ul>
+              <li><code>Mesh</code> — vertices, texcoords, normals, indices, bone weights, vaoId, vboId[]</li>
+              <li><code>Material</code> — shader + maps[] (diffuse, normal, roughness, …)</li>
+              <li><code>Model</code> — meshes[], materials[], meshMaterial[], skeleton, boneMatrices</li>
+            </ul>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/raylib.h#L345-L433">raylib.h — Mesh, Material, Model</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Skeletal animation</summary>
+          <div class="details-body">
+            <p><code>UpdateModelAnimation</code> computes bone transforms; <code>DrawModelEx</code> uploads <code>boneMatrices</code> to shader when <code>SHADER_LOC_MATRIX_BONETRANSFORMS</code> is available. GPU skinning off by default (<code>SUPPORT_GPU_SKINNING 0</code>) — CPU skinning via <code>mesh.animVertices</code>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Billboards</summary>
+          <div class="details-body">
+            <p><code>DrawBillboardPro</code> builds a camera-facing quad in 3D space and draws via textured vertices (still uses rl immediate path, not mesh VAO).</p>
+          </div>
+        </details>
+      </section>
+
+      <div class="callout searchable">
+        <p><strong>Caution:</strong> <code>DrawModelEx</code> multiplies into <code>model.transform</code> each call. Reset with <code>model.transform = MatrixIdentity()</code> if you reuse the same model at multiple positions per frame.</p>
+      </div>
+
+      <footer class="footer">
+        <p><a href="textures-and-images.html">← Textures &amp; images</a> · <a href="audio-system.html">Audio system →</a></p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/raylib-data-flow/components/modules-and-build.html
+++ b/explainers/raylib-data-flow/components/modules-and-build.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Modules &amp; build — raylib Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>raylib Data Flow</strong>
+        <span>raysan5/raylib @ <code>22509ab</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="frame-lifecycle.html">Frame lifecycle</a>
+        <a href="rlgl-batching.html">rlgl &amp; batching</a>
+        <a href="platform-backends.html">Platform backends</a>
+        <a href="textures-and-images.html">Textures &amp; images</a>
+        <a href="models-and-3d.html">Models &amp; 3D</a>
+        <a href="audio-system.html">Audio system</a>
+        <a href="modules-and-build.html" aria-current="page">Modules &amp; build</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Modules, config, and build systems</h1>
+          <p class="lead">raylib is configured at compile time through <code>src/config.h</code> and platform defines. Three build paths are maintained: GNU Make, CMake, and Zig.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>Source files → library</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>File</th><th>Module flag</th><th>Role</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>rcore.c</code></td><td>mandatory</td><td>Core + included platform</td></tr>
+              <tr><td><code>rlgl.h</code></td><td>mandatory</td><td>GL impl inside rcore</td></tr>
+              <tr><td><code>rshapes.c</code></td><td>SUPPORT_MODULE_RSHAPES</td><td>2D draw + collision</td></tr>
+              <tr><td><code>rtextures.c</code></td><td>SUPPORT_MODULE_RTEXTURES</td><td>Images &amp; textures</td></tr>
+              <tr><td><code>rtext.c</code></td><td>SUPPORT_MODULE_RTEXT</td><td>Fonts (needs rtextures)</td></tr>
+              <tr><td><code>rmodels.c</code></td><td>SUPPORT_MODULE_RMODELS</td><td>3D models</td></tr>
+              <tr><td><code>raudio.c</code></td><td>SUPPORT_MODULE_RAUDIO</td><td>Audio</td></tr>
+              <tr><td><code>rglfw.c</code></td><td>desktop GLFW</td><td>Vendored GLFW (separate .o in Make)</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/CMakeLists.txt#L32-L47">src/CMakeLists.txt — raylib_sources</a></p>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>GNU Make (common on Linux)</summary>
+          <div class="details-body">
+            <pre><code>cd raylib/src
+make PLATFORM=PLATFORM_DESKTOP
+
+cd raylib/examples
+make core/core_basic_window
+./core/core_basic_window</code></pre>
+            <p>Key flags: <code>PLATFORM</code>, <code>GRAPHICS</code>, <code>RAYLIB_BUILD_MODE=RELEASE</code>, <code>RAYLIB_CONFIG_FLAGS</code> for custom defines.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>CMake</summary>
+          <div class="details-body">
+            <pre><code>cmake -B build -DPLATFORM=Desktop -DBUILD_EXAMPLES=ON
+cmake --build build
+./build/examples/core/core_basic_window</code></pre>
+            <p><code>CUSTOMIZE_BUILD=ON</code> exposes every <code>SUPPORT_*</code> flag. <code>OPENGL_VERSION</code> selects graphics API.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Zig build</summary>
+          <div class="details-body">
+            <pre><code>zig build
+zig build core_basic_window    # run example</code></pre>
+            <p>Options: <code>-Dplatform=glfw|sdl2|drm|…</code>, <code>-Dopengl_version=gles_2</code>, module toggles <code>-Draudio=false</code>, etc.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Public headers</summary>
+          <div class="details-body">
+            <ul>
+              <li><code>raylib.h</code> — main API</li>
+              <li><code>raymath.h</code> — math (standalone with RAYMATH_IMPLEMENTATION)</li>
+              <li><code>rlgl.h</code> — GL layer (standalone with RLGL_IMPLEMENTATION)</li>
+              <li><code>rcamera.h</code>, <code>rgestures.h</code> — optional helpers</li>
+            </ul>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Tooling in repo</summary>
+          <div class="details-body">
+            <ul>
+              <li><code>tools/rlparser</code> — parses <code>raylib.h</code> → JSON/XML for bindings</li>
+              <li><code>tools/rexm</code> — validates and updates the examples collection</li>
+            </ul>
+            <p>No unit test suite — CI compiles library + examples on Linux, Windows, macOS, Android, Web.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Notable config defaults</summary>
+          <div class="details-body">
+            <ul>
+              <li><code>SUPPORT_CUSTOM_FRAME_CONTROL 0</code> — EndDrawing owns swap/poll</li>
+              <li><code>SUPPORT_GPU_SKINNING 0</code> — CPU bone skinning default</li>
+              <li><code>SUPPORT_FILEFORMAT_JPG 0</code> — JPG off unless enabled</li>
+              <li><code>RL_DEFAULT_BATCH_BUFFER_ELEMENTS 4096</code> — batch capacity</li>
+            </ul>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/config.h">config.h</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Dependency direction</h2>
+        <pre><code>raylib.h (types)
+    │
+rcore ──► rlgl ◄── rshapes, rtextures, rtext, rmodels
+    │              rtext ──► rtextures
+    │              rmodels ──► rtextures, raymath
+    └──► platform/*.c (included)
+
+raudio ──► miniaudio (independent)</code></pre>
+      </section>
+
+      <footer class="footer">
+        <p><a href="audio-system.html">← Audio system</a> · <a href="../index.html">Overview</a></p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/raylib-data-flow/components/platform-backends.html
+++ b/explainers/raylib-data-flow/components/platform-backends.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Platform backends — raylib Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>raylib Data Flow</strong>
+        <span>raysan5/raylib @ <code>22509ab</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="frame-lifecycle.html">Frame lifecycle</a>
+        <a href="rlgl-batching.html">rlgl &amp; batching</a>
+        <a href="platform-backends.html" aria-current="page">Platform backends</a>
+        <a href="textures-and-images.html">Textures &amp; images</a>
+        <a href="models-and-3d.html">Models &amp; 3D</a>
+        <a href="audio-system.html">Audio system</a>
+        <a href="modules-and-build.html">Modules &amp; build</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Platform backends: compile-time selection</h1>
+          <p class="lead">raylib supports many targets by swapping the platform implementation textually included into <code>rcore.c</code>. CMake/Makefile/Zig must agree on the same <code>PLATFORM_*</code> preprocessor define.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>Platform picker</h2>
+        <p>Tap a backend to see its define, source file, and notes.</p>
+        <div class="platform-grid" data-platform-grid>
+          <button type="button" class="platform-card" data-platform="glfw"><strong>Desktop GLFW</strong><code>default</code></button>
+          <button type="button" class="platform-card" data-platform="sdl"><strong>SDL</strong><code>SDL2 / SDL3</code></button>
+          <button type="button" class="platform-card" data-platform="rgfw"><strong>RGFW</strong><code>lightweight</code></button>
+          <button type="button" class="platform-card" data-platform="drm"><strong>DRM / Pi</strong><code>KMS</code></button>
+          <button type="button" class="platform-card" data-platform="web"><strong>Web</strong><code>Emscripten</code></button>
+          <button type="button" class="platform-card" data-platform="android"><strong>Android</strong><code>NDK</code></button>
+          <button type="button" class="platform-card" data-platform="memory"><strong>Memory</strong><code>headless</code></button>
+        </div>
+        <div class="arch-detail panel" style="margin-top:16px" aria-live="polite">
+          <p><strong>Define:</strong> <code data-platform-define>—</code></p>
+          <p><strong>File:</strong> <code data-platform-file>—</code></p>
+          <p data-platform-notes>—</p>
+        </div>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Preprocessor dispatch in rcore.c</h2>
+        <pre><code>#if defined(PLATFORM_DESKTOP)
+    #define PLATFORM_DESKTOP_GLFW
+#endif
+
+#if defined(PLATFORM_DESKTOP_GLFW)
+    #include "platforms/rcore_desktop_glfw.c"
+#elif defined(PLATFORM_DESKTOP_SDL)
+    #include "platforms/rcore_desktop_sdl.c"
+#elif defined(PLATFORM_DRM)
+    #include "platforms/rcore_drm.c"
+// ... etc
+#endif</code></pre>
+        <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L509-L535">rcore.c L509–535</a></p>
+        <div class="callout callout-warn">
+          <p>Platform <code>.c</code> files are <strong>not</strong> separate translation units — they share <code>CORE</code> and static platform state with <code>rcore.c</code> (unity-build style).</p>
+        </div>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>Platform contract — required functions</summary>
+          <div class="details-body">
+            <ul>
+              <li><code>int InitPlatform(void)</code> / <code>void ClosePlatform(void)</code></li>
+              <li><code>void SwapScreenBuffer(void)</code></li>
+              <li><code>void PollInputEvents(void)</code></li>
+              <li><code>bool WindowShouldClose(void)</code></li>
+              <li>Window/monitor/cursor/clipboard helpers</li>
+            </ul>
+            <p>Template: <code>platforms/rcore_template.c</code></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>GLFW InitPlatform (desktop default)</summary>
+          <div class="details-body">
+            <ol>
+              <li><code>glfwInit()</code> with RL_* alloc wrappers</li>
+              <li>Window hints from <code>CORE.Window.flags</code> (MSAA, resizable, HiDPI…)</li>
+              <li>OpenGL version from <code>rlGetVersion()</code></li>
+              <li><code>glfwCreateWindow</code>, <code>glfwMakeContextCurrent</code></li>
+              <li><code>rlLoadExtensions(glfwGetProcAddress)</code></li>
+              <li>Register input/window callbacks → update <code>CORE.Input</code></li>
+            </ol>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/platforms/rcore_desktop_glfw.c#L1436">rcore_desktop_glfw.c — InitPlatform</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>rglfw.c — vendored GLFW</summary>
+          <div class="details-body">
+            <p>When not using system GLFW, <code>rglfw.c</code> compiles all <code>external/glfw/src/*.c</code> into one object. CMake uses <code>GlfwImport.cmake</code>; Makefile links <code>rglfw.o</code> separately.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>CMake PLATFORM mapping</summary>
+          <div class="details-body">
+            <div class="table-wrap">
+              <table>
+                <thead><tr><th>CMake -DPLATFORM</th><th>C define</th></tr></thead>
+                <tbody>
+                  <tr><td>Desktop</td><td>PLATFORM_DESKTOP → GLFW</td></tr>
+                  <tr><td>SDL</td><td>PLATFORM_DESKTOP_SDL</td></tr>
+                  <tr><td>RGFW</td><td>PLATFORM_DESKTOP_RGFW</td></tr>
+                  <tr><td>Web</td><td>PLATFORM_WEB</td></tr>
+                  <tr><td>DRM</td><td>PLATFORM_DRM</td></tr>
+                  <tr><td>Android</td><td>PLATFORM_ANDROID</td></tr>
+                  <tr><td>Memory</td><td>PLATFORM_MEMORY</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </details>
+      </section>
+
+      <footer class="footer">
+        <p><a href="rlgl-batching.html">← rlgl &amp; batching</a> · <a href="textures-and-images.html">Textures &amp; images →</a></p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/raylib-data-flow/components/rlgl-batching.html
+++ b/explainers/raylib-data-flow/components/rlgl-batching.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>rlgl &amp; batching — raylib Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>raylib Data Flow</strong>
+        <span>raysan5/raylib @ <code>22509ab</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="frame-lifecycle.html">Frame lifecycle</a>
+        <a href="rlgl-batching.html" aria-current="page">rlgl &amp; batching</a>
+        <a href="platform-backends.html">Platform backends</a>
+        <a href="textures-and-images.html">Textures &amp; images</a>
+        <a href="models-and-3d.html">Models &amp; 3D</a>
+        <a href="audio-system.html">Audio system</a>
+        <a href="modules-and-build.html">Modules &amp; build</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>rlgl: OpenGL abstraction and render batching</h1>
+          <p class="lead"><code>rlgl.h</code> is a header-only OpenGL wrapper included with <code>#define RLGL_IMPLEMENTATION</code> from <code>rcore.c</code>. It exposes an immediate-mode API (<code>rlBegin</code>, <code>rlVertex2f</code>, <code>rlEnd</code>) that on modern GL accumulates vertices into CPU buffers and draws in few GPU calls.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section demo-panel searchable">
+        <h2>Interactive batch demo</h2>
+        <p>Add rectangles to the batch, then flush. Changing texture forces a flush (like <code>rlSetTexture</code> in real code).</p>
+        <div class="demo-toolbar">
+          <button type="button" data-batch-add>Add rect</button>
+          <button type="button" data-batch-flush>Flush batch</button>
+          <button type="button" data-batch-texture>Change texture</button>
+        </div>
+        <div class="demo-canvas-wrap">
+          <canvas data-batch-demo aria-label="Batch accumulation demo"></canvas>
+        </div>
+        <div class="demo-stats">
+          <div class="stat-box"><strong data-batch-count>0 verts</strong><span>In batch</span></div>
+          <div class="stat-box"><strong data-batch-dc>0</strong><span>Draw calls</span></div>
+          <div class="stat-box"><strong data-batch-tex>0</strong><span>Texture swaps</span></div>
+        </div>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>rlglInit creates GPU defaults</h2>
+        <pre><code>rlglInit(width, height)
+  ├─ 1×1 white RGBA texture (rlLoadTexture)
+  ├─ rlLoadShaderDefault() — MVP + texture0 shader
+  └─ rlLoadRenderBatch(RL_DEFAULT_BATCH_BUFFERS,
+                       RL_DEFAULT_BATCH_BUFFER_ELEMENTS)  // 4096 elements</code></pre>
+        <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rlgl.h#L2285-L2324">rlgl.h L2285–2324 — rlglInit</a></p>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>How DrawRectangle reaches the batch</summary>
+          <div class="details-body">
+            <p><code>DrawRectanglePro</code> calls <code>rlSetTexture(GetShapesTexture().id)</code>, then <code>rlBegin(RL_QUADS)</code>, four <code>rlVertex2f</code> + texcoords, <code>rlEnd</code>. Solid colors still use a 1×1 white texture so shapes batch with text.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rshapes.c#L777-L795">rshapes.c L777–795</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>When the batch flushes automatically</summary>
+          <div class="details-body">
+            <ul>
+              <li><code>rlDrawRenderBatchActive()</code> — explicit (EndDrawing, mode changes)</li>
+              <li><code>rlCheckRenderBatchLimit(vCount)</code> — buffer would overflow</li>
+              <li>Texture or shader change mid-batch</li>
+              <li>Switching draw mode in <code>rlBegin</code></li>
+            </ul>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rlgl.h#L3231-L3254">rlgl.h L3231–3254 — rlCheckRenderBatchLimit</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Graphics API selection (compile time)</summary>
+          <div class="details-body">
+            <p>Preprocessor flags: <code>GRAPHICS_API_OPENGL_33</code> (default desktop), <code>GRAPHICS_API_OPENGL_ES2</code> (mobile/web), <code>GRAPHICS_API_OPENGL_11</code>, <code>GRAPHICS_API_OPENGL_SOFTWARE</code> (rlsw).</p>
+            <p>CMake: <code>-DOPENGL_VERSION="ES 2.0"</code>. Makefile: <code>GRAPHICS=GRAPHICS_API_OPENGL_33</code> in CFLAGS.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Default shader contract</summary>
+          <div class="details-body">
+            <p>Attribute/uniform names are conventional so custom shaders can opt in:</p>
+            <ul>
+              <li><code>vertexPosition</code>, <code>vertexTexCoord</code>, <code>vertexColor</code></li>
+              <li><code>mvp</code> matrix, <code>texture0</code> sampler</li>
+            </ul>
+            <p>Defined in <code>config.h</code> / <code>rlgl.h</code> as <code>RL_DEFAULT_SHADER_*</code> macros.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>3D meshes bypass the batch</summary>
+          <div class="details-body">
+            <p><code>DrawMesh</code> binds material shader, sets uniforms, enables VAO/VBOs, and calls <code>glDrawElements</code> directly. Only 2D-style <code>rlBegin</code> paths use the default batch.</p>
+            <p>See <a href="models-and-3d.html">Models &amp; 3D</a>.</p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>rlglData structure (simplified)</h2>
+        <pre><code>rlglData RLGL {
+  rlRenderBatch defaultBatch;   // vertex buffers, draw call list
+  rlRenderBatch *currentBatch;
+  State {
+    currentTextureId, currentShaderId,
+    matrix stack, blend mode, viewport
+  }
+  ExtSupported { texCompDXT, texCompETC2, ... }
+}</code></pre>
+      </section>
+
+      <footer class="footer">
+        <p><a href="frame-lifecycle.html">← Frame lifecycle</a> · <a href="platform-backends.html">Platform backends →</a></p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/raylib-data-flow/components/textures-and-images.html
+++ b/explainers/raylib-data-flow/components/textures-and-images.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Textures &amp; images — raylib Data Flow</title>
+  <link rel="stylesheet" href="../assets/styles.css">
+  <script src="../assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>raylib Data Flow</strong>
+        <span>raysan5/raylib @ <code>22509ab</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="../index.html">Overview</a>
+        <a href="frame-lifecycle.html">Frame lifecycle</a>
+        <a href="rlgl-batching.html">rlgl &amp; batching</a>
+        <a href="platform-backends.html">Platform backends</a>
+        <a href="textures-and-images.html" aria-current="page">Textures &amp; images</a>
+        <a href="models-and-3d.html">Models &amp; 3D</a>
+        <a href="audio-system.html">Audio system</a>
+        <a href="modules-and-build.html">Modules &amp; build</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>Textures and images: RAM to VRAM</h1>
+          <p class="lead"><code>rtextures.c</code> splits pixel work into CPU-side <code>Image</code> operations and GPU-side <code>Texture2D</code>. Loading always goes through <code>LoadFileData</code> in rcore unless you use memory loaders.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>LoadTexture pipeline</h2>
+        <pre><code>LoadTexture("sprite.png")
+  │
+  ├─► LoadFileData()          [rcore.c — fopen entire file]
+  │
+  ├─► LoadImageFromMemory()   [extension → stb_image / qoi / …]
+  │       Image { data, width, height, format, mipmaps }
+  │
+  ├─► LoadTextureFromImage()
+  │       texture.id = rlLoadTexture(data, w, h, format, mipmaps)
+  │
+  └─► UnloadImage()           [RL_FREE CPU buffer]</code></pre>
+        <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rtextures.c#L4118-L4130">rtextures.c L4118–4130 — LoadTexture</a></p>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable">
+          <summary>Image — CPU memory</summary>
+          <div class="details-body">
+            <pre><code>typedef struct Image {
+    void *data;
+    int width, height, mipmaps, format;  // PixelFormat enum
+} Image;</code></pre>
+            <p>Procedural generators: <code>GenImageColor</code>, <code>GenImagePerlinNoise</code>, etc. CPU filters: <code>ImageResize</code>, <code>ImageBlurGaussian</code>, <code>ImageFormat</code> conversion.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Texture2D — GPU handle</summary>
+          <div class="details-body">
+            <pre><code>typedef struct Texture {
+    unsigned int id;   // OpenGL texture name
+    int width, height, mipmaps, format;
+} Texture2D;</code></pre>
+            <p><code>rlLoadTexture</code> checks GPU format support (<code>RLGL.ExtSupported</code>) before upload. Unsupported compressed formats log a warning and return id 0.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rlgl.h#L3259">rlgl.h — rlLoadTexture</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>DrawTexturePro → batch</summary>
+          <div class="details-body">
+            <p>Builds four corners (with rotation), sets <code>rlSetTexture(texture.id)</code>, emits quad to batch. Skips draw if <code>texture.id == 0</code>.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rtextures.c#L4512">rtextures.c — DrawTexturePro</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>RenderTexture2D (FBO)</summary>
+          <div class="details-body">
+            <p><code>BeginTextureMode</code> enables framebuffer, sets orthographic projection to texture size, updates <code>CORE.Window.currentFbo</code>. Drawing goes to GPU texture attachment instead of screen until <code>EndTextureMode</code>.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L996-L1045">rcore.c — BeginTextureMode / EndTextureMode</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>File format flags (config.h)</summary>
+          <div class="details-body">
+            <p>Enabled by default: PNG, BMP, GIF, QOI, DDS. Disabled by default: JPG, TGA, HDR, ASTC, KTX. Strip formats at compile time with <code>-DSUPPORT_FILEFORMAT_JPG=1</code> or CMake <code>CUSTOMIZE_BUILD=ON</code>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable">
+          <summary>Override file I/O</summary>
+          <div class="details-body">
+            <p><code>SetLoadFileDataCallback</code> lets embedded targets load from APK/assets or packfiles without changing rtextures code. Android CMake link flag: <code>-Wl,--wrap=fopen</code>.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L1944">rcore.c — LoadFileData</a></p>
+          </div>
+        </details>
+      </section>
+
+      <footer class="footer">
+        <p><a href="platform-backends.html">← Platform backends</a> · <a href="models-and-3d.html">Models &amp; 3D →</a></p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/explainers/raylib-data-flow/index.html
+++ b/explainers/raylib-data-flow/index.html
@@ -1,0 +1,246 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>raylib Data Flow — Overview</title>
+  <link rel="stylesheet" href="assets/styles.css">
+  <script src="assets/site.js" defer></script>
+</head>
+<body>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="brand">
+        <strong>raylib Data Flow</strong>
+        <span>raysan5/raylib @ <code>22509ab</code></span>
+      </div>
+      <nav class="nav" aria-label="Component pages">
+        <a href="index.html" aria-current="page">Overview</a>
+        <a href="components/frame-lifecycle.html">Frame lifecycle</a>
+        <a href="components/rlgl-batching.html">rlgl &amp; batching</a>
+        <a href="components/platform-backends.html">Platform backends</a>
+        <a href="components/textures-and-images.html">Textures &amp; images</a>
+        <a href="components/models-and-3d.html">Models &amp; 3D</a>
+        <a href="components/audio-system.html">Audio system</a>
+        <a href="components/modules-and-build.html">Modules &amp; build</a>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <div class="topbar">
+        <div>
+          <h1>From InitWindow to pixels on screen</h1>
+          <p class="lead">An interactive tour of how raylib turns your C game loop into windowed graphics and audio. raylib is a library — you own <code>main()</code> and the loop. This guide follows one frame from initialization through batched 2D draws, optional 3D mesh rendering, and input polling.</p>
+        </div>
+        <div class="controls">
+          <input type="search" placeholder="Filter blocks" aria-label="Filter blocks" data-search>
+          <button type="button" data-expand-all>Expand all</button>
+          <button type="button" data-collapse-all>Collapse all</button>
+        </div>
+      </div>
+      <p class="meta" data-search-count></p>
+
+      <section class="section panel searchable">
+        <h2>The mental model in one paragraph</h2>
+        <p>raylib is a <strong>modular C library</strong> built around two mandatory pieces — <code>rcore</code> (window, input, timing) and <code>rlgl</code> (OpenGL abstraction) — plus optional modules for shapes, textures, text, 3D models, and audio. You call <code>InitWindow()</code>, which boots a platform backend (GLFW by default), creates an OpenGL context, and initializes rlgl's default shader and render batch. Each frame you call <code>BeginDrawing()</code>, issue draw calls that accumulate geometry into a batch, then <code>EndDrawing()</code> flushes the batch, swaps buffers, limits FPS, and polls input. There is no built-in scene graph or entity system — just functions.</p>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Interactive architecture map</h2>
+        <p>Tap a module to see what it does and how it fits. Mandatory modules are marked.</p>
+        <div class="arch-map" data-arch-map>
+          <div class="arch-row">
+            <button type="button" class="arch-node" data-arch-node="app"><strong>Your main()</strong><span>Game loop owner</span></button>
+          </div>
+          <div class="arch-row">
+            <button type="button" class="arch-node" data-arch-node="rcore"><strong>rcore</strong><span><span class="badge badge-mandatory">mandatory</span></span></button>
+            <button type="button" class="arch-node" data-arch-node="platform"><strong>platform</strong><span>GLFW / SDL / …</span></button>
+          </div>
+          <div class="arch-row">
+            <button type="button" class="arch-node" data-arch-node="rlgl"><strong>rlgl</strong><span><span class="badge badge-mandatory">mandatory</span></span></button>
+          </div>
+          <div class="arch-row">
+            <button type="button" class="arch-node" data-arch-node="rshapes"><strong>rshapes</strong><span>2D primitives</span></button>
+            <button type="button" class="arch-node" data-arch-node="rtextures"><strong>rtextures</strong><span>Images &amp; textures</span></button>
+            <button type="button" class="arch-node" data-arch-node="rtext"><strong>rtext</strong><span>Fonts &amp; text</span></button>
+          </div>
+          <div class="arch-row">
+            <button type="button" class="arch-node" data-arch-node="rmodels"><strong>rmodels</strong><span>3D meshes</span></button>
+            <button type="button" class="arch-node" data-arch-node="raudio"><strong>raudio</strong><span>miniaudio</span></button>
+          </div>
+          <div class="arch-detail panel" aria-live="polite">
+            <h3 data-arch-title>Module</h3>
+            <p data-arch-body>Select a module above.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section demo-panel searchable">
+        <h2>Frame loop simulator</h2>
+        <p>What <code>EndDrawing()</code> does each frame on desktop (when <code>SUPPORT_CUSTOM_FRAME_CONTROL</code> is off). Use <strong>Step</strong> or <strong>Play</strong> on mobile.</p>
+        <div class="demo-toolbar">
+          <button type="button" data-demo-play>Play loop</button>
+          <button type="button" data-demo-step>Step</button>
+          <button type="button" data-demo-reset>Reset</button>
+        </div>
+        <div class="demo-canvas-wrap">
+          <canvas data-frame-demo aria-label="Frame loop animation"></canvas>
+        </div>
+        <div class="demo-stats">
+          <div class="stat-box"><strong data-stat-frame>0</strong><span>Frame #</span></div>
+          <div class="stat-box"><strong data-stat-step>Poll input</strong><span>Current phase</span></div>
+          <div class="stat-box"><strong data-stat-verts>0</strong><span>Batch vertices</span></div>
+        </div>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>Layer diagram</h2>
+        <pre><code>  YOUR CODE                    RAYLIB MODULES                 PLATFORM / GPU
+ ┌─────────────┐            ┌──────────────────┐           ┌─────────────────┐
+ │ main()      │  InitWindow│ rcore.c          │InitPlatform│ rcore_desktop_  │
+ │ while loop  │───────────►│  CORE global     │───────────►│ glfw.c          │
+ │ Draw*()     │            │  BeginDrawing    │           │  GLFW window    │
+ └─────────────┘            │  EndDrawing      │           │  GL context     │
+       │                    └────────┬─────────┘           └────────┬────────┘
+       │                             │ rlglInit / rlBegin            │ glfwSwapBuffers
+       ▼                             ▼                               ▼
+ DrawRectangle ──► rshapes ──► rlgl batch ──► glDrawElements ──► framebuffer
+ DrawTexture  ──► rtextures ──► rlLoadTexture
+ DrawModel    ──► rmodels  ──► DrawMesh (VAO, bypasses batch)
+ PlaySound    ──► raudio   ──► miniaudio callback (separate thread)</code></pre>
+      </section>
+
+      <section class="section panel searchable">
+        <h2>One frame, end to end</h2>
+        <p>Tap a step to jump to its explanation below.</p>
+        <div class="flow">
+          <button type="button" class="flow-step" data-flow-step="init">
+            <span class="step-label">0. InitWindow (once)</span>
+            <span><code>InitPlatform()</code> → <code>rlglInit()</code> → <code>LoadFontDefault()</code>. Sets up <code>CORE</code> and GPU defaults.</span>
+          </button>
+          <button type="button" class="flow-step" data-flow-step="begin">
+            <span class="step-label">1. BeginDrawing</span>
+            <span>Record <code>CORE.Time.update</code>, reset modelview, apply HiDPI <code>screenScale</code>.</span>
+          </button>
+          <button type="button" class="flow-step" data-flow-step="draw">
+            <span class="step-label">2. Draw calls</span>
+            <span><code>DrawRectangle</code>, <code>DrawTexturePro</code>, <code>DrawText</code> → <code>rlBegin</code>/<code>rlVertex</code>/<code>rlEnd</code> into batch.</span>
+          </button>
+          <button type="button" class="flow-step" data-flow-step="flush">
+            <span class="step-label">3. EndDrawing — flush</span>
+            <span><code>rlDrawRenderBatchActive()</code> uploads batch and issues GL draw calls.</span>
+          </button>
+          <button type="button" class="flow-step" data-flow-step="swap">
+            <span class="step-label">4. Swap &amp; timing</span>
+            <span><code>SwapScreenBuffer()</code>, <code>WaitTime()</code> for target FPS, <code>PollInputEvents()</code>.</span>
+          </button>
+          <button type="button" class="flow-step" data-flow-step="input">
+            <span class="step-label">5. Input queries</span>
+            <span><code>IsKeyPressed</code> compares <code>previousKeyState</code> vs <code>currentKeyState</code> updated during poll.</span>
+          </button>
+        </div>
+      </section>
+
+      <section class="section grid">
+        <details open class="searchable" data-flow-target="init">
+          <summary>0. Startup: InitWindow</summary>
+          <div class="details-body">
+            <p><code>InitWindow</code> in <code>rcore.c</code> initializes <code>CORE.Window</code> and <code>CORE.Input</code>, calls platform <code>InitPlatform()</code> (e.g. GLFW window + GL context), then <code>rlglInit(width, height)</code> which creates the 1×1 default texture, default shader, and render batch.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L585-L720">rcore.c L585–720 — InitWindow</a></p>
+            <p>Full detail: <a href="components/frame-lifecycle.html">Frame lifecycle</a>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="begin">
+          <summary>1. BeginDrawing resets the frame</summary>
+          <div class="details-body">
+            <p><code>BeginDrawing</code> captures update-phase delta time and resets the modelview matrix, applying <code>CORE.Window.screenScale</code> for HiDPI displays. It does not clear the screen — call <code>ClearBackground</code> yourself.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L858-L872">rcore.c L858–872 — BeginDrawing</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="draw">
+          <summary>2. Draw calls batch 2D geometry</summary>
+          <div class="details-body">
+            <p>Even solid rectangles bind a shared white texture and emit quads via <code>rlBegin(RL_QUADS)</code>. Text draws each glyph with <code>DrawTexturePro</code>. State changes (new texture/shader) or buffer overflow trigger a batch flush mid-frame.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rshapes.c#L738-L795">rshapes.c L738–795 — DrawRectanglePro</a></p>
+            <p>Full detail: <a href="components/rlgl-batching.html">rlgl &amp; batching</a>.</p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="flush">
+          <summary>3. EndDrawing flushes the batch</summary>
+          <div class="details-body">
+            <p>The first line of <code>EndDrawing</code> is <code>rlDrawRenderBatchActive()</code>, which uploads accumulated vertices and draws with the active shader (default MVP + texture0).</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L875-L917">rcore.c L875–917 — EndDrawing</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="swap">
+          <summary>4. Buffer swap and frame pacing</summary>
+          <div class="details-body">
+            <p>Unless custom frame control is enabled, <code>EndDrawing</code> calls <code>SwapScreenBuffer()</code> (platform), measures draw time, <code>WaitTime()</code> to hit <code>SetTargetFPS</code>, then <code>PollInputEvents()</code>.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/platforms/rcore_desktop_glfw.c#L1397-L1411">rcore_desktop_glfw.c — PollInputEvents</a></p>
+          </div>
+        </details>
+
+        <details open class="searchable" data-flow-target="input">
+          <summary>5. Input is edge-detected per frame</summary>
+          <div class="details-body">
+            <p><code>IsKeyPressed</code> returns true when a key transitioned from up to down since the last poll. Window close is tracked in <code>CORE.Window.shouldClose</code>, updated from GLFW each frame.</p>
+            <p class="coderef"><a href="https://github.com/raysan5/raylib/blob/22509ab/src/rcore.c#L3802-L3812">rcore.c L3802–3812 — IsKeyPressed</a></p>
+          </div>
+        </details>
+      </section>
+
+      <section class="section searchable">
+        <h2>Core objects</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>Object</th><th>Role</th><th>Defined in</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>CORE</code></td><td>Global window, input, timing state</td><td><code>rcore.c</code></td></tr>
+              <tr><td><code>RLGL</code></td><td>Render batch, shaders, GL state</td><td><code>rlgl.h</code></td></tr>
+              <tr><td><code>Image</code></td><td>CPU pixel buffer (RAM)</td><td><code>raylib.h</code></td></tr>
+              <tr><td><code>Texture2D</code></td><td>GPU texture handle + metadata</td><td><code>raylib.h</code></td></tr>
+              <tr><td><code>Font</code></td><td>Glyph atlas texture + metrics</td><td><code>raylib.h</code></td></tr>
+              <tr><td><code>Mesh</code> / <code>Model</code></td><td>3D geometry + materials on GPU</td><td><code>raylib.h</code></td></tr>
+              <tr><td><code>Sound</code></td><td>Static audio buffer in mixer list</td><td><code>raudio.c</code></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section grid searchable">
+        <div class="panel">
+          <h2>Component pages</h2>
+          <ul>
+            <li><a href="components/frame-lifecycle.html">Frame lifecycle</a> — InitWindow, loop, EndDrawing, CloseWindow</li>
+            <li><a href="components/rlgl-batching.html">rlgl &amp; batching</a> — immediate mode, flush rules, interactive batch demo</li>
+            <li><a href="components/platform-backends.html">Platform backends</a> — compile-time selection, GLFW boot</li>
+            <li><a href="components/textures-and-images.html">Textures &amp; images</a> — LoadFileData → stb → rlLoadTexture</li>
+            <li><a href="components/models-and-3d.html">Models &amp; 3D</a> — LoadModel, DrawMesh, BeginMode3D</li>
+            <li><a href="components/audio-system.html">Audio system</a> — miniaudio callback mixing</li>
+            <li><a href="components/modules-and-build.html">Modules &amp; build</a> — config.h, Make, CMake, Zig</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <h2>External references</h2>
+          <ul>
+            <li><a href="https://github.com/raysan5/raylib">raysan5/raylib</a> — source repository</li>
+            <li><a href="https://www.raylib.com/cheatsheet/cheatsheet.html">raylib cheatsheet</a></li>
+            <li><a href="https://github.com/raysan5/raylib/wiki/raylib-architecture">raylib architecture wiki</a></li>
+            <li><a href="https://www.raylib.com/examples.html">Live examples</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <footer class="footer">
+        <p>Educational walkthrough of <a href="https://github.com/raysan5/raylib">raysan5/raylib</a>. Code links pinned to commit <code>22509ab</code>. raylib is licensed under zlib/libpng.</p>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a mobile-friendly interactive HTML explainer for [raysan5/raylib](https://github.com/raysan5/raylib) under `explainers/raylib-data-flow/`, following the same pattern as `explainers/spark-data-flow/`.

## Contents

- **Overview** (`index.html`) — architecture map (tap modules), frame-loop canvas simulator, end-to-end flow steps with GitHub permalinks
- **Component pages** — frame lifecycle, rlgl batching (with interactive batch demo), platform backends (picker), textures/images, models/3D, audio, modules/build
- **Shared assets** — responsive CSS (sidebar collapses on mobile, 44px touch targets), search/filter, expand/collapse, flow-step highlighting

## How to view locally

Open `explainers/raylib-data-flow/index.html` in a browser (or serve the repo with any static file server).

## Notes

- Code references pinned to raylib commit `22509ab`
- No dependency on external JS/CSS CDNs — works offline
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3795507-3332-47cb-9164-b9e9c20ce785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3795507-3332-47cb-9164-b9e9c20ce785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

